### PR TITLE
Fix 'ftoptions' not defined error with FDW

### DIFF
--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -885,7 +885,7 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
 
             # /* Print per-table FDW options, if any */
             if (row[1]):
-                status.append("FDW Options: (%s)\n" % ftoptions)
+                status.append("FDW Options: (%s)\n" % row[1])
 
         #/* print inherited tables */
         sql = ("SELECT c.oid::pg_catalog.regclass FROM pg_catalog.pg_class c, "


### PR DESCRIPTION
Using MySQL FDW I had the following error when trying to describe my foreign table (`\d mytable`):
```
global name 'ftoptions' is not defined
```

I wasn't able to reproduce using Postgres built-in FDW. To test it you'll need MySQL FDW downloadable there:
http://pgxn.org/dist/mysql_fdw/

Then the minimal steps are (with MySQL root user, no password):
- on mysql : 
```sql
CREATE DATABASE fdwtest;
USE fdwtest;
CREATE TABLE test (id int);
```
- on postgresql
```sql
CREATE DATABASE fdwtest;
\c fdwtest
CREATE EXTENSION mysql_fdw;
CREATE SERVER myserver FOREIGN DATA WRAPPER mysql_fdw OPTIONS (host '127.0.0.1', port '3306');
CREATE USER MAPPING FOR postgres SERVER myserver OPTIONS (username 'root');
CREATE FOREIGN table dummy (id int) SERVER myserver OPTIONS (dbname 'fdwtest', table_name 'test');
\d dummy
```