### PR TITLE
Fix broken `\d tablename` command

### DIFF
--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -784,7 +784,7 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
                                 contype,
                                 condeferrable,
                                 condeferred,
-                                c2.reltablespace,
+                                c2.reltablespace
                         FROM pg_catalog.pg_class c,
                             pg_catalog.pg_class c2,
                             pg_catalog.pg_index i

--- a/tests/dbutils.py
+++ b/tests/dbutils.py
@@ -43,7 +43,7 @@ def setup_db(conn):
         cur.execute('create schema schema2')
 
         # tables
-        cur.execute('create table tbl1(id1 integer, txt1 text)')
+        cur.execute('create table tbl1(id1 integer, txt1 text, CONSTRAINT id_text PRIMARY KEY(id1, txt1))')
         cur.execute('create table tbl2(id2 integer, txt2 text)')
         cur.execute('create table schema1.s1_tbl1(id1 integer, txt1 text)')
 

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -16,6 +16,19 @@ def test_slash_d(executor):
 
 
 @dbtest
+def test_slash_d_table(executor):
+    results = executor('\d tbl1')
+    title = None
+    rows = [['id1', 'integer', ' not null'],
+            ['txt1', 'text', ' not null'],
+            ]
+    headers = ['Column', 'Type', 'Modifiers']
+    status = 'Indexes:\n    "id_text" PRIMARY KEY, btree (id1, txt1)\n'
+    expected = [title, rows, headers, status]
+    assert results == expected
+
+
+@dbtest
 def test_slash_dn(executor):
     """List all schemas."""
     results = executor('\dn')


### PR DESCRIPTION
#10 added support for `\d` and others for postgres 8 and inadvertently broke `\d` in pg9. It was my fault for testing in just pg8 and not 9.