### PR TITLE
Initial attempt at \copy command.

### DIFF
--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -101,6 +101,22 @@ def list_schemas(cur, pattern, verbose):
         headers = [x[0] for x in cur.description]
         return [(None, cur, headers, cur.statusmessage)]
 
+@special_command('\\copy', '\\copy [pattern]', 'Copy from a table to a file and vice versa.')
+def copy(cur, pattern, verbose):
+    """
+    Returns (title, rows, headers, status)
+    """
+    if not pattern:
+        return [(None, None, None, '\copy: arguments required.')]
+
+    sql = 'COPY ' + pattern
+    log.debug(sql)
+    cur.execute(sql)
+    if cur.description:
+        headers = [x[0] for x in cur.description]
+        return [(None, cur, headers, cur.statusmessage)]
+    return [(None, None, None, None)]
+
 
 def list_objects(cur, pattern, verbose, relkinds):
     """
@@ -1205,3 +1221,4 @@ def sql_name_pattern(pattern):
         schema = '^(' + schema + ')$'
 
     return schema, relname
+


### PR DESCRIPTION
This is an incorrect implementation of the `\copy` command in pgcli. 

The reason this is incorrect is because we're converting the `\copy` to a SQL `COPY` statement which is wrong, since a `COPY` statement implies the command is run in the server which means the file path specified in the SQL is relative to the server not the client. 

For example: 

```
\copy (select * from migrations) TO /tmp/foo.out
```

Will dump the output of the SQL statement to a file called /tmp/foo.out in the server, not in the client's machine in which pgcli is running. 

In order to implement it correctly, we need to do two things: 

1. Rewrite the above query to this: 

```
COPY (select * from migration) TO STDOUT
```

2. Use `copy_expert` in psycopg2 (http://initd.org/psycopg/docs/cursor.html#cursor.copy_expert), as follows:

```
copy_expert('COPY (select * from migration) TO STDOUT', open('/tmp/foo.out'))
```

There are a few additional complications to this approach. 

* The \copy command can have options after the filename as follows: 

```
\copy (select * from migration) TO 'filename with spaces.txt' WITH CSV HEADER 
```

So I'm looking for suggestions on how to do this replacement in a fail safe manner. 

I'd love to get some suggestions from @dbcli/pgcli-core team. 