### PR TITLE
Amjith/copy updates

### DIFF
--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -117,7 +117,7 @@ def copy(cur, pattern, verbose):
                                   after_file_name)
     open_mode = 'r' if direction == 'FROM' else 'w'
     if file_name.startswith("'") and file_name.endswith("'"):
-        file = open(file_name.strip("'"), open_mode)
+        file = io.open(expanduser(file_name.strip("'")), mode=open_mode, encoding='utf-8')
     elif 'stdin' in file_name.lower():
         file = sys.stdin
     elif 'stdout' in file_name.lower():


### PR DESCRIPTION
This is a PR to address the comments left in #16 (Thank you for doing the heavy lifting @catherinedevlin). 

The \copy command can now handle path names with ~ in them. 

I've also updated the tests to use the tmpdir fixture in py.test. 

Reviewer: @drocco007 or @stuartquin 