### PR TITLE
Added \sf command handling

### DIFF
--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -75,7 +75,7 @@ def list_roles(cur, pattern, verbose):
 
 
 @special_command('\\db', '\\db[+] [pattern]', 'List tablespaces.')
-def list_tablestpaces(cur, pattern, **_):
+def list_tablespaces(cur, pattern, **_):
     """
     Returns (title, rows, headers, status)
     """
@@ -367,6 +367,31 @@ def list_functions(cur, pattern, verbose):
     if cur.description:
         headers = [x[0] for x in cur.description]
         return [(None, cur, headers, cur.statusmessage)]
+
+
+@special_command('\\sf', '\\sf[+] FUNCNAME', 'Show a function\'s definition.')
+def get_function_definition(cur, pattern, verbose):
+
+    if '(' in pattern:
+        query = 'SELECT %s::pg_catalog.regprocedure::pg_catalog.oid'
+    else:
+        query = 'SELECT %s::pg_catalog.regproc::pg_catalog.oid'
+
+    sql = cur.mogrify(query, [pattern])
+
+    log.debug(sql)
+    cur.execute(sql)
+    func_oid = cur.fetchone()
+
+    query = 'SELECT pg_catalog.pg_get_functiondef(%s) AS "Function definition";'
+
+    sql = cur.mogrify(query, [func_oid])
+
+    log.debug(sql)
+    cur.execute(sql)
+
+    headers = [x[0] for x in cur.description] if cur.description else None
+    return [(None, cur, headers, None)]
 
 
 @special_command('\\dT', '\\dT[S+] [pattern]', 'List data types')

--- a/pgspecial/main.py
+++ b/pgspecial/main.py
@@ -240,7 +240,6 @@ def doc_only():
 
 
 @special_command('\\ef', '\\ef [funcname [line]]', 'Edit the contents of the query buffer.', arg_type=NO_QUERY, hidden=True)
-@special_command('\\sf', '\\sf[+] FUNCNAME', 'Show a function\'s definition.', arg_type=NO_QUERY, hidden=True)
 @special_command('\\do', '\\do[S] [pattern]', 'List operators.', arg_type=NO_QUERY, hidden=True)
 @special_command('\\dp', '\\dp [pattern]', 'List table, view, and sequence access privileges.', arg_type=NO_QUERY, hidden=True)
 @special_command('\\z', '\\z [pattern]', 'Same as \\dp.', arg_type=NO_QUERY, hidden=True)

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -102,7 +102,28 @@ def test_slash_df(executor):
     expected = [title, rows, headers, status]
     assert results == expected
 
+
+@dbtest
+def test_slash_sf(executor):
+    """Get definition of a function"""
+    title, rows, header, status = executor('\sf func1')
+    assert title is None
+    assert 'CREATE' in rows[0][0]
+    assert header == ['Function definition']
+    assert status is None
+
+@dbtest
+def test_slash_sf_with_parenthesis_used(executor):
+    """Get definition of a function with parenthesis used in pattern"""
+    title, rows, header, status = executor('\sf schema1.s1_func1()')
+    assert title is None
+    assert 'CREATE' in rows[0][0]
+    assert header == ['Function definition']
+    assert status is None
+
+
 help_rows = [['ABORT', 'ALTER AGGREGATE', 'ALTER COLLATION', 'ALTER CONVERSION', 'ALTER DATABASE', 'ALTER DEFAULT PRIVILEGES'], ['ALTER DOMAIN', 'ALTER EVENT TRIGGER', 'ALTER EXTENSION', 'ALTER FOREIGN DATA WRAPPER', 'ALTER FOREIGN TABLE', 'ALTER FUNCTION'], ['ALTER GROUP', 'ALTER INDEX', 'ALTER LANGUAGE', 'ALTER LARGE OBJECT', 'ALTER MATERIALIZED VIEW', 'ALTER OPCLASS'], ['ALTER OPERATOR', 'ALTER OPFAMILY', 'ALTER POLICY', 'ALTER ROLE', 'ALTER RULE', 'ALTER SCHEMA'], ['ALTER SEQUENCE', 'ALTER SERVER', 'ALTER SYSTEM', 'ALTER TABLE', 'ALTER TABLESPACE', 'ALTER TRIGGER'], ['ALTER TSCONFIG', 'ALTER TSDICTIONARY', 'ALTER TSPARSER', 'ALTER TSTEMPLATE', 'ALTER TYPE', 'ALTER USER'], ['ALTER USER MAPPING', 'ALTER VIEW', 'ANALYZE', 'BEGIN', 'CHECKPOINT', 'CLOSE'], ['CLUSTER', 'COMMENT', 'COMMIT', 'COMMIT PREPARED', 'COPY', 'CREATE AGGREGATE'], ['CREATE CAST', 'CREATE COLLATION', 'CREATE CONVERSION', 'CREATE DATABASE', 'CREATE DOMAIN', 'CREATE EVENT TRIGGER'], ['CREATE EXTENSION', 'CREATE FOREIGN DATA WRAPPER', 'CREATE FOREIGN TABLE', 'CREATE FUNCTION', 'CREATE GROUP', 'CREATE INDEX'], ['CREATE LANGUAGE', 'CREATE MATERIALIZED VIEW', 'CREATE OPCLASS', 'CREATE OPERATOR', 'CREATE OPFAMILY', 'CREATE POLICY'], ['CREATE ROLE', 'CREATE RULE', 'CREATE SCHEMA', 'CREATE SEQUENCE', 'CREATE SERVER', 'CREATE TABLE'], ['CREATE TABLE AS', 'CREATE TABLESPACE', 'CREATE TRANSFORM', 'CREATE TRIGGER', 'CREATE TSCONFIG', 'CREATE TSDICTIONARY'], ['CREATE TSPARSER', 'CREATE TSTEMPLATE', 'CREATE TYPE', 'CREATE USER', 'CREATE USER MAPPING', 'CREATE VIEW'], ['DEALLOCATE', 'DECLARE', 'DELETE', 'DISCARD', 'DO', 'DROP AGGREGATE'], ['DROP CAST', 'DROP COLLATION', 'DROP CONVERSION', 'DROP DATABASE', 'DROP DOMAIN', 'DROP EVENT TRIGGER'], ['DROP EXTENSION', 'DROP FOREIGN DATA WRAPPER', 'DROP FOREIGN TABLE', 'DROP FUNCTION', 'DROP GROUP', 'DROP INDEX'], ['DROP LANGUAGE', 'DROP MATERIALIZED VIEW', 'DROP OPCLASS', 'DROP OPERATOR', 'DROP OPFAMILY', 'DROP OWNED'], ['DROP POLICY', 'DROP ROLE', 'DROP RULE', 'DROP SCHEMA', 'DROP SEQUENCE', 'DROP SERVER'], ['DROP TABLE', 'DROP TABLESPACE', 'DROP TRANSFORM', 'DROP TRIGGER', 'DROP TSCONFIG', 'DROP TSDICTIONARY'], ['DROP TSPARSER', 'DROP TSTEMPLATE', 'DROP TYPE', 'DROP USER', 'DROP USER MAPPING', 'DROP VIEW'], ['END', 'EXECUTE', 'EXPLAIN', 'FETCH', 'GRANT', 'IMPORT FOREIGN SCHEMA'], ['INSERT', 'LISTEN', 'LOAD', 'LOCK', 'MOVE', 'NOTIFY'], ['PGBENCH', 'PREPARE', 'PREPARE TRANSACTION', 'REASSIGN OWNED', 'REFRESH MATERIALIZED VIEW', 'REINDEX'], ['RELEASE SAVEPOINT', 'RESET', 'REVOKE', 'ROLLBACK', 'ROLLBACK PREPARED', 'ROLLBACK TO'], ['SAVEPOINT', 'SECURITY LABEL', 'SELECT', 'SELECT INTO', 'SET', 'SET CONSTRAINTS'], ['SET ROLE', 'SET SESSION AUTH', 'SET TRANSACTION', 'SHOW', 'START TRANSACTION', 'TRUNCATE'], ['UNLISTEN', 'UPDATE', 'VACUUM', 'VALUES']]
+
 
 @dbtest
 def test_slash_h(executor):
@@ -111,6 +132,7 @@ def test_slash_h(executor):
     expected = [None, help_rows, [], None]
     assert results == expected
 
+
 @dbtest
 def test_slash_h_command(executor):
     """Check help is returned for all commands"""
@@ -118,6 +140,7 @@ def test_slash_h_command(executor):
         results = executor('\h %s' % command)
         assert results[3].startswith('Description\n')
         assert 'Syntax' in results[3]
+
 
 @dbtest
 def test_slash_h_alias(executor):


### PR DESCRIPTION
I have added brief handling of \sf command. I am not sure whether it could be used at it is in pgcli, as original \sf in psql doesn't show function definition in a table like view, only text is shown. This implementation also do not handle verbose mode for \sf as I could not figure it out what this mode changes here (besides code indentation..).

Additionally I have made some minor changes to surrounding code.