### PR TITLE
Break out `\e` removal into `get_editor_query()`

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,12 @@
+TBD
+===
+
+Features:
+---------
+
+* Opening an external editor will edit default text. (Thanks: `Thomas Roten`_).
+
+
 1.7.0
 =====
 
@@ -43,7 +52,7 @@ Features:
 Features:
 ---------
 
-* Add initial support for Postgres 8.4 and above.(Thanks: `Timothy Cleaver`_, darikg_). 
+* Add initial support for Postgres 8.4 and above.(Thanks: `Timothy Cleaver`_, darikg_).
   This enables us to add support for Amazon Redshift. If things look broken please report.
 
 * Add \pset pager command. (Thanks: `pik`_).
@@ -92,3 +101,4 @@ Features:
 .. _`Joakim Koljonen`: https://github.com/koljonen
 .. _`Emanuele Gaifas`: https://github.com/lelit
 .. _`Marcin Sztolcman`: https://github.com/msztolcman
+.. _`Thomas Roten`: https://github.com/tsroten

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -43,13 +43,8 @@ def get_watch_command(command):
 
 
 @export
-def open_external_editor(filename=None, sql='', default_text=''):
-    """
-    Open external editor, wait for the user to type in his query,
-    return the query.
-    :return: list with one tuple, query as first element.
-    """
-
+def get_editor_query(sql):
+    """Get the query part of an editor command."""
     sql = sql.strip()
 
     # The reason we can't simply do .strip('\e') is that it strips characters,
@@ -59,16 +54,27 @@ def open_external_editor(filename=None, sql='', default_text=''):
     while pattern.search(sql):
         sql = pattern.sub('', sql)
 
-    text = sql or default_text
+    return sql
+
+
+@export
+def open_external_editor(filename=None, sql=None):
+    """
+    Open external editor, wait for the user to type in his query,
+    return the query.
+    :return: list with one tuple, query as first element.
+    """
+
     message = None
     filename = filename.strip().split(' ', 1)[0] if filename else None
 
+    sql = sql or ''
     MARKER = '# Type your query above this line.\n'
 
     # Populate the editor buffer with the partial sql (if available) and a
     # placeholder comment.
-    query = click.edit(text + '\n\n' + MARKER, filename=filename,
-            extension='.sql')
+    query = click.edit('{sql}\n\n{marker}'.format(sql=sql, marker=MARKER),
+                       filename=filename, extension='.sql')
 
     if filename:
         try:

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -43,7 +43,7 @@ def get_watch_command(command):
 
 
 @export
-def open_external_editor(filename=None, sql=''):
+def open_external_editor(filename=None, sql='', default_text=''):
     """
     Open external editor, wait for the user to type in his query,
     return the query.
@@ -59,6 +59,7 @@ def open_external_editor(filename=None, sql=''):
     while pattern.search(sql):
         sql = pattern.sub('', sql)
 
+    text = sql or default_text
     message = None
     filename = filename.strip().split(' ', 1)[0] if filename else None
 
@@ -66,7 +67,7 @@ def open_external_editor(filename=None, sql=''):
 
     # Populate the editor buffer with the partial sql (if available) and a
     # placeholder comment.
-    query = click.edit(sql + '\n\n' + MARKER, filename=filename,
+    query = click.edit(text + '\n\n' + MARKER, filename=filename,
             extension='.sql')
 
     if filename:


### PR DESCRIPTION
This is part of a PR for https://github.com/dbcli/pgcli/issues/434.

Port from mycli: https://github.com/dbcli/mycli/pull/425

It breaks out the `\e` removal from the editor command into `get_editor_query()` so that pgcli can provide `pgspecial` with the correct query to edit (possibly the previous query).