### PR TITLE
Watch command can be separated from query by more than just space.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,7 +1,7 @@
 Upcoming
 ========
 
-* TBD
+* Be less strict when searching for the `\watch` command. (Thanks: `Irina Truong`_).
 
 1.8.0
 =====

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -35,7 +35,7 @@ def get_filename(sql):
 
 @export
 def get_watch_command(command):
-    match = re.match("(.*) \\\\watch (\d+);?$", command)
+    match = re.match("(.*?)[ \t\n]*\\\\watch (\d+);?$", command)
     if match:
         groups = match.groups()
         return groups[0], int(groups[1])

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -35,7 +35,7 @@ def get_filename(sql):
 
 @export
 def get_watch_command(command):
-    match = re.match("(.*?)[ \t\n]*\\\\watch (\d+);?$", command)
+    match = re.match("(.*?)[\s]*\\\\watch (\d+);?$", command)
     if match:
         groups = match.groups()
         return groups[0], int(groups[1])


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

This is to address https://github.com/dbcli/pgcli/issues/544. When looking for `\watch` command at the end of the statement, we can't rely on it always being separated by a space.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
