### PR TITLE
Fix \d on tables with exclusion constraint

### DIFF
--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -924,6 +924,7 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
 
                 #/* If exclusion constraint, print the constraintdef */
                 if row[7] == "x":
+                    status.append(' ')
                     status.append(row[6])
                 else:
                     #/* Label as primary key or unique (but not both) */

--- a/tests/dbutils.py
+++ b/tests/dbutils.py
@@ -47,6 +47,7 @@ def setup_db(conn):
         cur.execute('create table tbl1(id1 integer, txt1 text, CONSTRAINT id_text PRIMARY KEY(id1, txt1))')
         cur.execute('create table tbl2(id2 serial, txt2 text)')
         cur.execute('create table schema1.s1_tbl1(id1 integer, txt1 text)')
+        cur.execute('create table tbl3(c3 circle, exclude using gist (c3 with &&))')
 
         # views
         cur.execute('create view vw1 as select * from tbl1')

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -15,9 +15,10 @@ def test_slash_d(executor):
             ('public', 'tbl1', 'table', POSTGRES_USER),
             ('public', 'tbl2', 'table', POSTGRES_USER),
             ('public', 'tbl2_id2_seq', 'sequence', POSTGRES_USER),
+            ('public', 'tbl3', 'table', POSTGRES_USER),
             ('public', 'vw1', 'view', POSTGRES_USER)]
     headers = objects_listing_headers[:-2]
-    status = 'SELECT 5'
+    status = 'SELECT 6'
     expected = [title, rows, headers, status]
 
     assert results == expected
@@ -31,9 +32,10 @@ def test_slash_d_verbose(executor):
             ('public', 'tbl1', 'table', POSTGRES_USER, '8192 bytes', None),
             ('public', 'tbl2', 'table', POSTGRES_USER, '8192 bytes', None),
             ('public', 'tbl2_id2_seq', 'sequence', POSTGRES_USER, '8192 bytes', None),
+            ('public', 'tbl3', 'table', POSTGRES_USER, '0 bytes', None),
             ('public', 'vw1', 'view', POSTGRES_USER, '0 bytes', None)]
     headers = objects_listing_headers
-    status = 'SELECT 5'
+    status = 'SELECT 6'
     expected = [title, rows, headers, status]
 
     assert results == expected
@@ -66,6 +68,17 @@ def test_slash_d_table_verbose(executor):
 
 
 @dbtest
+def test_slash_d_table_with_exclusion(executor):
+    results = executor('\d tbl3')
+    title = None
+    rows = [['c3', 'circle', '']]
+    headers = ['Column', 'Type', 'Modifiers']
+    status = 'Indexes:\n    "tbl3_c3_excl" EXCLUDE USING gist (c3 WITH &&)\n'
+    expected = [title, rows, headers, status]
+    assert results == expected
+
+
+@dbtest
 def test_slash_dn(executor):
     """List all schemas."""
     results = executor('\dn')
@@ -85,9 +98,10 @@ def test_slash_dt(executor):
     results = executor('\dt')
     title = None
     rows = [('public', 'tbl1', 'table', POSTGRES_USER),
-            ('public', 'tbl2', 'table', POSTGRES_USER)]
+            ('public', 'tbl2', 'table', POSTGRES_USER),
+            ('public', 'tbl3', 'table', POSTGRES_USER)]
     headers = objects_listing_headers[:-2]
-    status = 'SELECT 2'
+    status = 'SELECT 3'
     expected = [title, rows, headers, status]
     assert results == expected
 
@@ -98,9 +112,10 @@ def test_slash_dt_verbose(executor):
     results = executor('\dt+')
     title = None
     rows = [('public', 'tbl1', 'table', POSTGRES_USER, '8192 bytes', None),
-            ('public', 'tbl2', 'table', POSTGRES_USER, '8192 bytes', None)]
+            ('public', 'tbl2', 'table', POSTGRES_USER, '8192 bytes', None),
+            ('public', 'tbl3', 'table', POSTGRES_USER, '0 bytes', None)]
     headers = objects_listing_headers
-    status = 'SELECT 2'
+    status = 'SELECT 3'
     expected = [title, rows, headers, status]
     assert results == expected
 
@@ -182,9 +197,10 @@ def test_slash_di(executor):
     """List all indexes in public schema."""
     results = executor('\di')
     title = None
-    row = [('public', 'id_text', 'index', POSTGRES_USER)]
+    row = [('public', 'id_text', 'index', POSTGRES_USER),
+           ('public', 'tbl3_c3_excl', 'index', POSTGRES_USER)]
     headers = objects_listing_headers[:-2]
-    status = 'SELECT 1'
+    status = 'SELECT 2'
     expected = [title, row, headers, status]
     assert results == expected
 
@@ -194,9 +210,10 @@ def test_slash_di_verbose(executor):
     """List all indexes in public schema in verbose mode."""
     results = executor('\di+')
     title = None
-    row = [('public', 'id_text', 'index', POSTGRES_USER, '8192 bytes', None)]
+    row = [('public', 'id_text', 'index', POSTGRES_USER, '8192 bytes', None),
+           ('public', 'tbl3_c3_excl', 'index', POSTGRES_USER, '8192 bytes', None)]
     headers = objects_listing_headers
-    status = 'SELECT 1'
+    status = 'SELECT 2'
     expected = [title, row, headers, status]
     assert results == expected
 


### PR DESCRIPTION
The description of the index created by an EXCLUDE constraint is missing a space.