### PR TITLE
Change list to match psql results

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -3,6 +3,7 @@ Upcoming
 
 * Be less strict when searching for the `\watch` command. (Thanks: `Irina Truong`_).
 * Fix glitch in ``EXCLUDE`` index description emitted by \d command. (Thanks: `Lele Gaifax`_).
+* Change `\l` command behavior, and add `\list` alias. (Thanks: `François Pietka`_).
 
 1.8.0
 =====


### PR DESCRIPTION
## Description
Change `\l` behavior to match `psql`, and add `\list` alias.
see dbcli/pgcli#674


## Checklist
- [x] I've added this contribution to the `changelog.rst`.
