### PR TITLE
Fpietka/fix backslash e handling

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,7 @@ Upcoming
 * Be less strict when searching for the `\watch` command. (Thanks: `Irina Truong`_).
 * Fix glitch in ``EXCLUDE`` index description emitted by \d command. (Thanks: `Lele Gaifax`_).
 * Change `\l` command behavior, and add `\list` alias. (Thanks: `François Pietka`_).
+* Fix `\e` command handling. (Thanks: `François Pietka`_).
 
 1.8.0
 =====

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -23,7 +23,7 @@ def editor_command(command):
     """
     # It is possible to have `\e filename` or `SELECT * FROM \e`. So we check
     # for both conditions.
-    return command.strip().endswith('\\e') or command.strip().startswith('\\e')
+    return command.strip().endswith('\\e') or command.strip().startswith('\\e ')
 
 
 @export

--- a/pgspecial/main.py
+++ b/pgspecial/main.py
@@ -240,6 +240,7 @@ def doc_only():
 
 
 @special_command('\\ef', '\\ef [funcname [line]]', 'Edit the contents of the query buffer.', arg_type=NO_QUERY, hidden=True)
+@special_command('\\ev', '\\ev [viewname [line]]', 'Edit the contents of the query buffer.', arg_type=NO_QUERY, hidden=True)
 @special_command('\\do', '\\do[S] [pattern]', 'List operators.', arg_type=NO_QUERY, hidden=True)
 @special_command('\\dp', '\\dp [pattern]', 'List table, view, and sequence access privileges.', arg_type=NO_QUERY, hidden=True)
 @special_command('\\z', '\\z [pattern]', 'Same as \\dp.', arg_type=NO_QUERY, hidden=True)


### PR DESCRIPTION
## Description
Fix `\e` handling so it doesn't catch `\ef` or `\ev` commands.


## Checklist
- [x] I've added this contribution to the `changelog.rst`.
