### PR TITLE
python27: Fix UnicodeEncodeError in open_external_editor

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -115,3 +115,4 @@ Features:
 .. _`Thomas Roten`: https://github.com/tsroten
 .. _`Lele Gaifax`: https://github.com/lelit
 .. _`rsc`: https://github.com/rafalcieslinski
+.. _`Klaus Wünschel`: https://github.com/kwuenschel

--- a/changelog.rst
+++ b/changelog.rst
@@ -5,6 +5,7 @@ Upcoming
 * Fix glitch in ``EXCLUDE`` index description emitted by \d command. (Thanks: `Lele Gaifax`_).
 * Change `\l` command behavior, and add `\list` alias. (Thanks: `François Pietka`_).
 * Fix `\e` command handling. (Thanks: `François Pietka`_).
+* Fix UnicodeEncodeError when opening sql statement in editor (Thanks: `Klaus Wünschel`_).
 
 1.8.0
 =====

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -73,7 +73,7 @@ def open_external_editor(filename=None, sql=None):
 
     # Populate the editor buffer with the partial sql (if available) and a
     # placeholder comment.
-    query = click.edit('{sql}\n\n{marker}'.format(sql=sql, marker=MARKER),
+    query = click.edit(u'{sql}\n\n{marker}'.format(sql=sql, marker=MARKER),
                        filename=filename, extension='.sql')
 
     if filename:


### PR DESCRIPTION
Fix UnicodeEncodeError when opening a sql-statement that contains non
ASCII-characters in an external editor.

## Description
Ensures that the format string is unicode in python 2.7 and non-ASCII SQL-statements are converted properly.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [X] I've added this contribution to the `changelog.rst`.
