### PR TITLE
Fix inherits

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -6,7 +6,7 @@ Upcoming
 * Change `\l` command behavior, and add `\list` alias. (Thanks: `François Pietka`_).
 * Fix `\e` command handling. (Thanks: `François Pietka`_).
 * Fix UnicodeEncodeError when opening sql statement in editor (Thanks: `Klaus Wünschel`_).
-* Fix listing of child tables. (Thanks: `Lele Gaifax`_)
+* Fix listing of child tables in `\d` command. (Thanks: `Lele Gaifax`_)
 
 1.8.0
 =====

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,7 @@ Upcoming
 * Change `\l` command behavior, and add `\list` alias. (Thanks: `François Pietka`_).
 * Fix `\e` command handling. (Thanks: `François Pietka`_).
 * Fix UnicodeEncodeError when opening sql statement in editor (Thanks: `Klaus Wünschel`_).
+* Fix listing of child tables. (Thanks: `Lele Gaifax`_)
 
 1.8.0
 =====

--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -1178,7 +1178,7 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
     #*/
     if (tableinfo.relkind == 'r' or tableinfo.relkind == 'm' or
             tableinfo.relkind == 'f'):
-        # /* print foreign server name */
+        #/* print foreign server name */
         if tableinfo.relkind == 'f':
             #/* Footer information about foreign table */
             sql = ("SELECT s.srvname,\n"
@@ -1193,10 +1193,10 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
             cur.execute(sql)
             row = cur.fetchone()
 
-            # /* Print server name */
+            #/* Print server name */
             status.append("Server: %s\n" % row[0])
 
-            # /* Print per-table FDW options, if any */
+            #/* Print per-table FDW options, if any */
             if (row[1]):
                 status.append("FDW Options: (%s)\n" % row[1])
 

--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -1240,7 +1240,7 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
             #/* print the number of child tables, if any */
             if (cur.rowcount > 0):
                 status.append("Number of child tables: %d (Use \d+ to list"
-                    " them.)\n" % cur.rowcount)
+                              " them.)\n" % cur.rowcount)
         else:
             if (cur.rowcount > 0):
                 status.append('Child tables')

--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -1240,7 +1240,7 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
             #/* print the number of child tables, if any */
             if (cur.rowcount > 0):
                 status.append("Number of child tables: %d (Use \d+ to list"
-                    "them.)\n" % cur.rowcount)
+                    " them.)\n" % cur.rowcount)
         else:
             if (cur.rowcount > 0):
                 status.append('Child tables')

--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -1242,14 +1242,18 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
                 status.append("Number of child tables: %d (Use \d+ to list"
                     "them.)\n" % cur.rowcount)
         else:
-            spacer = ''
-            if (cur.rowcount >0):
+            if (cur.rowcount > 0):
                 status.append('Child tables')
 
-            #/* display the list of child tables */
-            for row in cur:
-                status.append("%s: %s,\n" % (spacer, row))
-                spacer = ' ' * len('Child tables')
+                spacer = ':'
+                trailer = ',\n'
+                #/* display the list of child tables */
+                for idx, row in enumerate(cur, 1):
+                    if idx == 2:
+                        spacer = ' ' * (len('Child tables') + 1)
+                    if idx == cur.rowcount:
+                        trailer = '\n'
+                    status.append("%s %s%s" % (spacer, row[0], trailer))
 
         #/* Table type */
         if (tableinfo.reloftype):

--- a/tests/dbutils.py
+++ b/tests/dbutils.py
@@ -48,6 +48,8 @@ def setup_db(conn):
         cur.execute('create table tbl2(id2 serial, txt2 text)')
         cur.execute('create table schema1.s1_tbl1(id1 integer, txt1 text)')
         cur.execute('create table tbl3(c3 circle, exclude using gist (c3 with &&))')
+        cur.execute('create table "Inh1"(value1 integer) inherits (tbl1)')
+        cur.execute('create table inh2(value2 integer) inherits (tbl1, tbl2)')
 
         # views
         cur.execute('create view vw1 as select * from tbl1')

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -56,7 +56,7 @@ def test_slash_d_table_1(executor):
             ]
     headers = ['Column', 'Type', 'Modifiers']
     status = ('Indexes:\n    "id_text" PRIMARY KEY, btree (id1, txt1)\n'
-              'Number of child tables: 2 (Use \\d+ to listthem.)\n')
+              'Number of child tables: 2 (Use \\d+ to list them.)\n')
     expected = [title, rows, headers, status]
     assert results == expected
 
@@ -69,7 +69,7 @@ def test_slash_d_table_2(executor):
             ['txt2', 'text', ''],
             ]
     headers = ['Column', 'Type', 'Modifiers']
-    status = ('Number of child tables: 1 (Use \\d+ to listthem.)\n')
+    status = ('Number of child tables: 1 (Use \\d+ to list them.)\n')
     expected = [title, rows, headers, status]
     assert results == expected
 

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -11,14 +11,16 @@ objects_listing_headers = ['Schema', 'Name', 'Type', 'Owner', 'Size', 'Descripti
 def test_slash_d(executor):
     results = executor('\d')
     title = None
-    rows = [('public', 'mvw1', 'materialized view', POSTGRES_USER),
+    rows = [('public', 'Inh1', 'table', POSTGRES_USER),
+            ('public', 'inh2', 'table', POSTGRES_USER),
+            ('public', 'mvw1', 'materialized view', POSTGRES_USER),
             ('public', 'tbl1', 'table', POSTGRES_USER),
             ('public', 'tbl2', 'table', POSTGRES_USER),
             ('public', 'tbl2_id2_seq', 'sequence', POSTGRES_USER),
             ('public', 'tbl3', 'table', POSTGRES_USER),
             ('public', 'vw1', 'view', POSTGRES_USER)]
     headers = objects_listing_headers[:-2]
-    status = 'SELECT 6'
+    status = 'SELECT 8'
     expected = [title, rows, headers, status]
 
     assert results == expected
@@ -28,41 +30,75 @@ def test_slash_d(executor):
 def test_slash_d_verbose(executor):
     results = executor('\d+')
     title = None
-    rows = [('public', 'mvw1', 'materialized view', POSTGRES_USER, '8192 bytes', None),
+    rows = [('public', 'Inh1', 'table', POSTGRES_USER, '8192 bytes', None),
+            ('public', 'inh2', 'table', POSTGRES_USER, '8192 bytes', None),
+            ('public', 'mvw1', 'materialized view', POSTGRES_USER, '8192 bytes', None),
             ('public', 'tbl1', 'table', POSTGRES_USER, '8192 bytes', None),
             ('public', 'tbl2', 'table', POSTGRES_USER, '8192 bytes', None),
             ('public', 'tbl2_id2_seq', 'sequence', POSTGRES_USER, '8192 bytes', None),
             ('public', 'tbl3', 'table', POSTGRES_USER, '0 bytes', None),
             ('public', 'vw1', 'view', POSTGRES_USER, '0 bytes', None)]
     headers = objects_listing_headers
-    status = 'SELECT 6'
+    status = 'SELECT 8'
     expected = [title, rows, headers, status]
 
     assert results == expected
 
 
 @dbtest
-def test_slash_d_table(executor):
+def test_slash_d_table_1(executor):
     results = executor('\d tbl1')
     title = None
     rows = [['id1', 'integer', ' not null'],
             ['txt1', 'text', ' not null'],
             ]
     headers = ['Column', 'Type', 'Modifiers']
-    status = 'Indexes:\n    "id_text" PRIMARY KEY, btree (id1, txt1)\n'
+    status = ('Indexes:\n    "id_text" PRIMARY KEY, btree (id1, txt1)\n'
+              'Number of child tables: 2 (Use \\d+ to listthem.)\n')
     expected = [title, rows, headers, status]
     assert results == expected
 
 
 @dbtest
-def test_slash_d_table_verbose(executor):
+def test_slash_d_table_2(executor):
+    results = executor('\d tbl2')
+    title = None
+    rows = [['id2', 'integer', " not null default nextval('tbl2_id2_seq'::regclass)"],
+            ['txt2', 'text', ''],
+            ]
+    headers = ['Column', 'Type', 'Modifiers']
+    status = ('Number of child tables: 1 (Use \\d+ to listthem.)\n')
+    expected = [title, rows, headers, status]
+    assert results == expected
+
+
+@dbtest
+def test_slash_d_table_verbose_1(executor):
     results = executor('\d+ tbl1')
     title = None
     rows = [['id1', 'integer', ' not null', 'plain', None, None],
             ['txt1', 'text', ' not null', 'extended', None, None],
             ]
     headers = ['Column', 'Type', 'Modifiers', 'Storage', 'Stats target', 'Description']
-    status = 'Indexes:\n    "id_text" PRIMARY KEY, btree (id1, txt1)\nHas OIDs: no\n'
+    status = ('Indexes:\n    "id_text" PRIMARY KEY, btree (id1, txt1)\n'
+              'Child tables: "Inh1",\n'
+              '              inh2\n'
+              'Has OIDs: no\n')
+    expected = [title, rows, headers, status]
+    assert results == expected
+
+
+@dbtest
+def test_slash_d_table_verbose_2(executor):
+    results = executor('\d+ tbl2')
+    title = None
+    rows = [['id2', 'integer', " not null default nextval('tbl2_id2_seq'::regclass)",
+             'plain', None, None],
+            ['txt2', 'text', '', 'extended', None, None],
+            ]
+    headers = ['Column', 'Type', 'Modifiers', 'Storage', 'Stats target', 'Description']
+    status = ('Child tables: inh2\n'
+              'Has OIDs: no\n')
     expected = [title, rows, headers, status]
     assert results == expected
 
@@ -97,11 +133,13 @@ def test_slash_dt(executor):
     """List all tables in public schema."""
     results = executor('\dt')
     title = None
-    rows = [('public', 'tbl1', 'table', POSTGRES_USER),
+    rows = [('public', 'Inh1', 'table', POSTGRES_USER),
+            ('public', 'inh2', 'table', POSTGRES_USER),
+            ('public', 'tbl1', 'table', POSTGRES_USER),
             ('public', 'tbl2', 'table', POSTGRES_USER),
             ('public', 'tbl3', 'table', POSTGRES_USER)]
     headers = objects_listing_headers[:-2]
-    status = 'SELECT 3'
+    status = 'SELECT 5'
     expected = [title, rows, headers, status]
     assert results == expected
 
@@ -111,11 +149,13 @@ def test_slash_dt_verbose(executor):
     """List all tables in public schema in verbose mode."""
     results = executor('\dt+')
     title = None
-    rows = [('public', 'tbl1', 'table', POSTGRES_USER, '8192 bytes', None),
+    rows = [('public', 'Inh1', 'table', POSTGRES_USER, '8192 bytes', None),
+            ('public', 'inh2', 'table', POSTGRES_USER, '8192 bytes', None),
+            ('public', 'tbl1', 'table', POSTGRES_USER, '8192 bytes', None),
             ('public', 'tbl2', 'table', POSTGRES_USER, '8192 bytes', None),
             ('public', 'tbl3', 'table', POSTGRES_USER, '0 bytes', None)]
     headers = objects_listing_headers
-    status = 'SELECT 3'
+    status = 'SELECT 5'
     expected = [title, rows, headers, status]
     assert results == expected
 

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -32,10 +32,12 @@ def test_slash_d_verbose(executor):
     title = None
     rows = [('public', 'Inh1', 'table', POSTGRES_USER, '8192 bytes', None),
             ('public', 'inh2', 'table', POSTGRES_USER, '8192 bytes', None),
-            ('public', 'mvw1', 'materialized view', POSTGRES_USER, '8192 bytes', None),
+            ('public', 'mvw1', 'materialized view',
+             POSTGRES_USER, '8192 bytes', None),
             ('public', 'tbl1', 'table', POSTGRES_USER, '8192 bytes', None),
             ('public', 'tbl2', 'table', POSTGRES_USER, '8192 bytes', None),
-            ('public', 'tbl2_id2_seq', 'sequence', POSTGRES_USER, '8192 bytes', None),
+            ('public', 'tbl2_id2_seq', 'sequence',
+             POSTGRES_USER, '8192 bytes', None),
             ('public', 'tbl3', 'table', POSTGRES_USER, '0 bytes', None),
             ('public', 'vw1', 'view', POSTGRES_USER, '0 bytes', None)]
     headers = objects_listing_headers
@@ -79,7 +81,8 @@ def test_slash_d_table_verbose_1(executor):
     rows = [['id1', 'integer', ' not null', 'plain', None, None],
             ['txt1', 'text', ' not null', 'extended', None, None],
             ]
-    headers = ['Column', 'Type', 'Modifiers', 'Storage', 'Stats target', 'Description']
+    headers = ['Column', 'Type', 'Modifiers',
+               'Storage', 'Stats target', 'Description']
     status = ('Indexes:\n    "id_text" PRIMARY KEY, btree (id1, txt1)\n'
               'Child tables: "Inh1",\n'
               '              inh2\n'
@@ -96,7 +99,8 @@ def test_slash_d_table_verbose_2(executor):
              'plain', None, None],
             ['txt2', 'text', '', 'extended', None, None],
             ]
-    headers = ['Column', 'Type', 'Modifiers', 'Storage', 'Stats target', 'Description']
+    headers = ['Column', 'Type', 'Modifiers',
+               'Storage', 'Stats target', 'Description']
     status = ('Child tables: inh2\n'
               'Has OIDs: no\n')
     expected = [title, rows, headers, status]

--- a/tox.ini
+++ b/tox.ini
@@ -4,4 +4,4 @@ envlist = py27, py33, py34, py35, py36
 deps = pytest
     mock
     psycopg2
-commands = py.test
+commands = py.test {posargs}


### PR DESCRIPTION
## Description
Currently when a table has children, the `\d` command outputs something like
```
Inherits: ('parent_table_a',),
        : ('parent_table_b',),
```
that is

- it emits the whole record tuple, instead of just the table name
- it always adds a trailing comma
- it repeats the colon on every row

With this PR it would emit something like
```
Inherits: parent_table_a,
          parent_table_b
```

matching the output of the corresponding command in `psql`.

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
