### PR TITLE
add  ...  as param in query favorite

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -5,7 +5,7 @@ Features:
 ---------
 
 * Add support for ``\dD`` command. (Thanks: `Lele Gaifax`_).
-* Add support parameter $1...£n in query (Thanks: `Frederic Aoustin`_).
+* Add support parameter $1...$n in query (Thanks: `Frederic Aoustin`_).
 
 Bug fixes:
 ----------

--- a/changelog.rst
+++ b/changelog.rst
@@ -5,6 +5,7 @@ Features:
 ---------
 
 * Add support for ``\dD`` command. (Thanks: `Lele Gaifax`_).
+* Add support parameter $1...£n in query (Thanks: `Frederic Aoustin`_).
 
 Bug fixes:
 ----------

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -153,7 +153,7 @@ def copy(cur, pattern, verbose):
 
 
 def subst_favorite_query_args(query, args):
-    """replace positional parameters ($1...$N) in query"""
+    """replace positional parameters ($1...$N) in query."""
     for idx, val in enumerate(args):
         subst_var = '$' + str(idx + 1)
         if subst_var not in query:

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -151,6 +151,7 @@ def copy(cur, pattern, verbose):
     else:
         return [(None, None, None, cur.statusmessage)]
 
+
 def subst_favorite_query_args(query, args):
     """replace positional parameters ($1...$N) in query."""
     for idx, val in enumerate(args):

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -185,6 +185,8 @@ def execute_named_query(cur, pattern, **_):
     try:
         if "$1" in query:
             query, params = subst_favorite_query_args(query, params)
+            if query is None:
+                raise Exception("Bad arguments\n" + params)
         cur.execute(query, params)
     except (IndexError, TypeError):
         raise Exception("Bad arguments")

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -153,7 +153,7 @@ def copy(cur, pattern, verbose):
 
 
 def subst_favorite_query_args(query, args):
-    """replace positional parameters ($1...$N) in query."""
+    """replace positional parameters ($1,$2,...$n) in query"""
     for idx, val in enumerate(args):
         subst_var = '$' + str(idx + 1)
         if subst_var not in query:

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -153,7 +153,7 @@ def copy(cur, pattern, verbose):
 
 
 def subst_favorite_query_args(query, args):
-    """replace positional parameters ($1,$2,...$n) in query"""
+    """replace positional parameters ($1,$2,...$n) in query."""
     for idx, val in enumerate(args):
         subst_var = '$' + str(idx + 1)
         if subst_var not in query:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

same working between mycli and pgcli about substiting parameters in favorite queries.

sample of usage

```
> create table test(id integer, lib varchar(25)
> insert into test(id,lib) values (1,'test')
> \ns test select * from test where id=$1
> \n test 1
+------+-------+
| id   | lib   |
|------+-------|
| 1    | test  |
+------+-------+
> \ns test select * from test where id=$1
> \n test 1
+------+-------+
| id   | lib   |
|------+-------|
| 1    | test  |
+------+-------+
```

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`.
