### PR TITLE
To format multiple objects, the right operand must be a tuple

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,8 @@ pgcli_: A REPL for Postgres.
 
 `ipython-sql`_: %%sql magic for IPython
 
+OmniDB_: An web tool for database management
+
 If you find this module useful and include it in your project, I'll be happy
 to know about it and list it here.
 
@@ -80,3 +82,4 @@ to know about it and list it here.
 
 .. _pgcli: https://github.com/dbcli/pgcli
 .. _`ipython-sql`: https://github.com/catherinedevlin/ipython-sql
+.. _OmniDB: https://github.com/OmniDB/OmniDB

--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -1067,7 +1067,7 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
                 status.append("Check constraints:\n")
             for row in cur:
                 #/* untranslated contraint name and def */
-                status.append("    \"%s\" %s" % row)
+                status.append("    \"%s\" %s" % tuple(row))
                 status.append('\n')
 
         #/* print foreign-key constraints (there are none if no triggers) */
@@ -1083,7 +1083,7 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
                 status.append("Foreign-key constraints:\n")
             for row in cur:
                 #/* untranslated constraint name and def */
-                status.append("    \"%s\" %s\n" % row)
+                status.append("    \"%s\" %s\n" % tuple(row))
 
         #/* print incoming foreign-key references (none if no triggers) */
         if (tableinfo.hastriggers):
@@ -1097,7 +1097,7 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
             if (cur.rowcount > 0):
                 status.append("Referenced by:\n")
             for row in cur:
-                status.append("    TABLE \"%s\" CONSTRAINT \"%s\" %s\n" % row)
+                status.append("    TABLE \"%s\" CONSTRAINT \"%s\" %s\n" % tuple(row))
 
         # /* print rules */
         if (tableinfo.hasrules and tableinfo.relkind != 'm'):


### PR DESCRIPTION
## Description

First of all, thank you for developing `pgspecial`, it is awesome! :)

Now for the PR description. To format multiple objects, the right operand must be a tuple. For example, (from [here](https://github.com/dbcli/pgspecial/blob/master/pgspecial/dbcommands.py#L1086)):

```python
status.append("    \"%s\" %s\n" % row)
```

The right operand is a list, not a tuple. So it will raise the error `TypeError: not enough arguments for format string`.

To fix this, I changed all similar formatting to be like:

```python
status.append("    \"%s\" %s\n" % tuple(row))
```

This was first reported by @erdusa in issue [424](https://github.com/OmniDB/OmniDB/issues/424) from [OmniDB](https://github.com/OmniDB/OmniDB).

I also included OmniDB as a project using `pgspecial`.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`.
