### PR TITLE
Disable usage of "%s"

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -16,6 +16,7 @@ Bug fixes:
 ----------
 
 * Fix listing of table inheritance in ``\d`` command. (Thanks: `Lele Gaifax`_).
+* Avoid the need to escape "%" in named queries (dbcli/pgcli#865). (Thanks: `Jason Ribeiro`_).
 
 1.9.0
 =====
@@ -144,3 +145,4 @@ Features:
 .. _`rsc`: https://github.com/rafalcieslinski
 .. _`Klaus Wünschel`: https://github.com/kwuenschel
 .. _`Frederic Aoustin`: https://github.com/fraoustin
+.. _`Jason Ribeiro`: https://github.com/jrib

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -192,7 +192,7 @@ def execute_named_query(cur, pattern, **_):
     except psycopg2.ProgrammingError as e:
         if e.pgcode == psycopg2.errorcodes.SYNTAX_ERROR and "%s" in query:
             raise Exception('Bad arguments: '
-                'please use "$1", "$2", etc. for named queries instead of "%s"')
+                            'please use "$1", "$2", etc. for named queries instead of "%s"')
         else:
             raise
     except (IndexError, TypeError):

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -188,7 +188,13 @@ def execute_named_query(cur, pattern, **_):
             query, params = subst_favorite_query_args(query, params)
             if query is None:
                 raise Exception("Bad arguments\n" + params)
-        cur.execute(query, params)
+        cur.execute(query)
+    except psycopg2.ProgrammingError as e:
+        if e.pgcode == psycopg2.errorcodes.SYNTAX_ERROR and "%s" in query:
+            raise Exception('Bad arguments: '
+                'please use "$1", "$2", etc. for named queries instead of "%s"')
+        else:
+            raise
     except (IndexError, TypeError):
         raise Exception("Bad arguments")
 


### PR DESCRIPTION
## Description

Users can already use parameters with "$N".  This makes it so that users
do not need to escape "%" with "%%" when using named queries.

See dbcli/pgcli#865.

The documentation on the website will have to be updated; is that on git somewhere?

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
