### PR TITLE
Adapt the query used to list the function to PG11

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,6 +8,7 @@ Bug fixes:
 ----------
 
 * Remove pycache files from release (Thanks: `Dick Marinus`_).
+* Fix ``\df`` under PG11. (Thanks: `Lele Gaifax`_).
 
 1.11.0
 ======


### PR DESCRIPTION
Under PG11, pg_catalog.pg_proc have a new single column, `prokind`, that carries the
information previously stored by two distinct boolean columns, `proisagg` and `proiswindow`.

This complements the fix to dbcli/pgcli#919.