### PR TITLE
Handle \ef without a filename.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,11 @@
+Upcoming
+========
+
+Bug fixes:
+----------
+
+* Fixed the IndexError caused by ``\ef`` without a function name. (Thanks: `Amjith Ramanujam`_)
+
 1.11.2
 ======
 

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -28,7 +28,7 @@ def editor_command(command):
     # for both conditions.
 
     stripped = command.strip()
-    for sought in ('\\e ', '\\ev ', '\\ef'):
+    for sought in ('\\e ', '\\ev ', '\\ef '):
         if stripped.startswith(sought):
             return sought.strip()
     for sought in ('\\e', ):


### PR DESCRIPTION
## Description
Typing `\ef` and pressing Enter causes IndexError. This will fix that.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
