### PR TITLE
add minimal version check for pg_class.reloptions query in \d+ command

### DIFF
--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -613,7 +613,7 @@ def describe_table_details(cur, pattern, verbose):
 
 
 def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
-    if verbose:
+    if verbose and cur.connection.server_version >= 80200:
         suffix = """pg_catalog.array_to_string(c.reloptions || array(select
         'toast.' || x from pg_catalog.unnest(tc.reloptions) x), ', ')"""
     else:


### PR DESCRIPTION
## Description
pg_class.reloptions was introduced in postgres 8.2. This change fixes \d+ command for Redshift.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
