### PR TITLE
Use unicode for special commands.

### DIFF
--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import logging
 from collections import namedtuple
 

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from contextlib import contextmanager
 import re
 import sys

--- a/pgspecial/main.py
+++ b/pgspecial/main.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import os
 import logging
 from collections import namedtuple


### PR DESCRIPTION
## Description
Use unicode strings for special commands. This is required to work with the latest prompt-toolkit.

I have NOT added tests for it yet. I'll have to look into adding unit tests in the pgcli repo for this. 


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`.
