### PR TITLE
Handle name of test database more consistently

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,11 @@
 import pytest
-from dbutils import (create_db, db_connection, setup_db, teardown_db)
+from dbutils import (create_db, db_connection, setup_db, teardown_db, TEST_DB_NAME)
 from pgspecial.main import PGSpecial
-
 
 @pytest.yield_fixture(scope='module')
 def connection():
-    create_db('_test_db')
-    connection = db_connection('_test_db')
+    create_db(TEST_DB_NAME)
+    connection = db_connection(TEST_DB_NAME)
     setup_db(connection)
     yield connection
 

--- a/tests/dbutils.py
+++ b/tests/dbutils.py
@@ -30,7 +30,7 @@ dbtest = pytest.mark.skipif(
 
 
 def create_db(dbname=TEST_DB_NAME):
-    with db_connection().cursor() as cur:
+    with db_connection(dbname=None).cursor() as cur:
         try:
             cur.execute('''CREATE DATABASE %s''' % dbname)
         except:

--- a/tests/dbutils.py
+++ b/tests/dbutils.py
@@ -6,6 +6,7 @@ import psycopg2.extras
 # TODO: should this be somehow be divined from environment?
 POSTGRES_USER, POSTGRES_HOST = 'postgres', 'localhost'
 
+TEST_DB_NAME = '_test_db'
 
 def db_connection(dbname=None):
     conn = psycopg2.connect(user=POSTGRES_USER, host=POSTGRES_HOST,
@@ -13,9 +14,8 @@ def db_connection(dbname=None):
     conn.autocommit = True
     return conn
 
-
 try:
-    conn = db_connection()
+    conn = db_connection(dbname=None)
     CAN_CONNECT_TO_DB = True
     SERVER_VERSION = conn.server_version
 except:
@@ -29,10 +29,10 @@ dbtest = pytest.mark.skipif(
            "'%s'" % POSTGRES_USER)
 
 
-def create_db(dbname):
+def create_db(dbname=TEST_DB_NAME):
     with db_connection().cursor() as cur:
         try:
-            cur.execute('''CREATE DATABASE _test_db''')
+            cur.execute('''CREATE DATABASE %s''' % dbname)
         except:
             pass
 


### PR DESCRIPTION
- Store name for test db in a constant in tests/dbutils.py
- Respect dbname passed to db_connection

## Description

Make test utilities a little more consistent by making use of the argument received in db_connection



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`.

(no, because it's not a feature, it's a trivial internal refactoring to the tests