### PR TITLE
Support \dE (describe foreign tables)

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Features:
 
 * Add support for the ``\!`` command. (Thanks: `Ignacio Campabadal`_).
 * Add support for describing text search configurations `\dF``. (Thanks: `Ignacio Campabadal`_).
+* Add support for the ``\dE`` command. (Thanks: `Catherine Devlin`_).
 
 1.11.4
 =======

--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -1633,3 +1633,28 @@ def shell_command(cur, pattern, verbose):
     cur, headers = [], []
     params = shlex.split(pattern)
     return [(None, cur, headers, subprocess.call(params))]
+
+# @special_command('\\l', '\\l[+] [pattern]', 'List databases.', aliases=('\\list',))
+@special_command('\\dE', '\\dE[+] [pattern]', 'List foreign tables.', aliases=() )
+def list_foreign_tables(cur, pattern, verbose):
+    query = '''
+        SELECT n.nspname as "Schema",
+        c.relname as "Name",
+        CASE c.relkind WHEN 'r' THEN 'table' WHEN 'v' THEN 'view' WHEN 'm' THEN 'materialized view' WHEN 'i' THEN 'index' WHEN 'S' THEN 'sequence' WHEN 's' THEN 'special' WHEN 'f' THEN 'foreign table' WHEN 'p' THEN 'table' WHEN 'I' THEN 'index' END as "Type",
+        pg_catalog.pg_get_userbyid(c.relowner) as "Owner"
+        FROM pg_catalog.pg_class c
+            LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind IN ('f','')
+            AND n.nspname <> 'pg_catalog'
+            AND n.nspname <> 'information_schema'
+            AND n.nspname !~ '^pg_toast'
+        AND pg_catalog.pg_table_is_visible(c.oid)
+        ORDER BY 1,2;
+        '''
+    cur.execute(query)
+    if cur.description:
+        headers = [x[0] for x in cur.description]
+        return [(None, cur, headers, cur.statusmessage)]
+    else:
+        return [(None, None, None, cur.statusmessage)]
+

--- a/tests/dbutils.py
+++ b/tests/dbutils.py
@@ -95,7 +95,7 @@ def setup_foreign(conn):
 
     foreign_conn = db_connection(FOREIGN_TEST_DB_NAME)
     with foreign_conn.cursor() as foreign_cur:
-        foreign_cur.execute('create table foreign_foo (a int, b text)')
+        foreign_cur.execute('create table if not exists foreign_foo (a int, b text)')
 
     with conn.cursor() as cur:
 
@@ -105,10 +105,10 @@ def setup_foreign(conn):
                     "foreign data wrapper postgres_fdw "
                     "options (host '127.0.0.1', dbname %s )", 
                     (FOREIGN_TEST_DB_NAME, ))
-        cur.execute("create user mapping for current_user "
+        cur.execute("create user mapping if not exists for current_user "
                     "server foreign_db_server "
                     "options (user 'postgres') ")
-        cur.execute("create foreign table foreign_foo (a int, b text) "
+        cur.execute("create foreign table if not exists foreign_foo (a int, b text) "
                     "server foreign_db_server "
                     "options (schema_name 'public', table_name 'foreign_foo') ")
        

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -1,7 +1,7 @@
   #!/usr/bin/python
   # -*- coding: utf-8 -*-
 
-from dbutils import dbtest, POSTGRES_USER
+from dbutils import dbtest, POSTGRES_USER, foreign_db_environ
 import itertools
 
 objects_listing_headers = ['Schema', 'Name', 'Type', 'Owner', 'Size', 'Description']
@@ -526,3 +526,15 @@ def test_slash_sf_verbose(executor):
     status = None
     expected = [title, rows, headers, status]
     assert results == expected
+
+@dbtest
+def test_slash_dE(executor):
+
+    with foreign_db_environ():
+        results = executor('\dE')
+        title = None
+        rows = [('public', 'foreign_foo', 'foreign table', 'postgres')]
+        headers =  ['Schema', 'Name', 'Type', 'Owner']
+        status = 'SELECT 1'
+        expected = [title, rows, headers, status]
+        assert results == expected

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -538,3 +538,36 @@ def test_slash_dE(executor):
         status = 'SELECT 1'
         expected = [title, rows, headers, status]
         assert results == expected
+
+@dbtest
+def test_slash_dE_with_pattern(executor):
+
+    with foreign_db_environ():
+        results = executor('\dE foreign_foo')
+        title = None
+        rows = [('public', 'foreign_foo', 'foreign table', 'postgres')]
+        headers =  ['Schema', 'Name', 'Type', 'Owner']
+        status = 'SELECT 1'
+        expected = [title, rows, headers, status]
+        assert results == expected
+
+        results = executor('\dE *_foo')
+        assert results == expected
+
+        results = executor('\dE no_such_table')
+        rows = []
+        status = 'SELECT 0'
+        expected = [title, rows, headers, status]
+        assert results == expected
+
+@dbtest
+def test_slash_dE_verbose(executor):
+
+    with foreign_db_environ():
+        results = executor('\dE+')
+        title = None
+        rows = [('public', 'foreign_foo', 'foreign table', 'postgres', '0 bytes', None)]
+        headers = ['Schema', 'Name', 'Type', 'Owner', 'Size', 'Description']
+        status = 'SELECT 1'
+        expected = [title, rows, headers, status]
+        assert results == expected


### PR DESCRIPTION
Added \dE, \dE+, \dE <pattern> support.



## Checklist

- [x] I've added this contribution to the `changelog.rst`.
