### PR TITLE
Make \d a_schema.a_table work

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,11 @@
+TBD
+===
+
+Bug fixes:
+----------
+
+* ``\d some_schema.some_table`` will now work when ``some_schema`` is not in your ``search_path``.
+
 1.11.7
 ======
 

--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -688,11 +688,11 @@ def describe_table_details(cur, pattern, verbose):
     where = []
     params = []
 
-    where.append('pg_catalog.pg_table_is_visible(c.oid)')
-
     if schema:
         where.append('n.nspname ~ %s')
         params.append(schema)
+    else:
+        where.append('pg_catalog.pg_table_is_visible(c.oid)')
 
     if relname:
         where.append('c.relname OPERATOR(pg_catalog.~) %s')

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -145,6 +145,19 @@ def test_slash_d_table_with_exclusion(executor):
 
 
 @dbtest
+def test_slash_d_table_2_in_schema(executor):
+    results = executor('\d schema2.tbl2')
+    title = None
+    rows = [['id2', 'integer', " not null default nextval('schema2.tbl2_id2_seq'::regclass)"],
+            ['txt2', 'text', ''],
+            ]
+    headers = ['Column', 'Type', 'Modifiers']
+    status = ''
+    expected = [title, rows, headers, status]
+    assert results == expected
+
+
+@dbtest
 def test_slash_dn(executor):
     """List all schemas."""
     results = executor('\dn')


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

PR #80 restricted `\d` to only schemas in the session's search
path, even when the schema was given as part of the `\d` command.
This commit attempts to make `\d` properly inspect the table in the
schema when the schema is given as part of the pattern.

Fixes #88.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
