### PR TITLE
Support listing single named query

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,11 @@
+1.11.11
+========
+
+Features:
+---------
+
+* Add support for the `\dp` metacommand that lists the privileges of Postgres objects (Thanks: `Guru Devanla`_)
+
 1.11.10
 ======
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -5,6 +5,7 @@ Features:
 ---------
 
 * Add support for the `\dp` metacommand that lists the privileges of Postgres objects (Thanks: `Guru Devanla`_)
+* Add support for the `\np <named_query_pattern>` metacommand that returns named queries matching the pattern (Thanks: `Guru Devanla`_)
 
 1.11.10
 ======

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -234,11 +234,15 @@ def list_named_queries(verbose):
         status = ''
     return [('', rows, headers, status)]
 
+
 @special_command('\\np', '\\np name_pattern', 'Print a named query.')
 def get_named_query(pattern, **_):
-    """Get a named query that matches name_pattern. The named pattern can be
-    a regular expression.
-    Returns (title, rows, headers, status)"""
+    """Get a named query that matches name_pattern.
+
+    The named pattern can be a regular expression. Returns (title,
+    rows, headers, status)
+
+    """
 
     usage = 'Syntax: \\np name.\n\n' + NamedQueries.instance.usage
     if not pattern:
@@ -247,7 +251,7 @@ def get_named_query(pattern, **_):
     name = pattern.strip()
     if (not name):
         return [(None, None, None,
-            usage + 'Err: A name is required.')]
+                 usage + 'Err: A name is required.')]
 
     headers = ["Name", "Query"]
     rows = [(r, NamedQueries.instance.get(r))
@@ -278,7 +282,6 @@ def save_named_query(pattern, **_):
 
     NamedQueries.instance.save(name, query)
     return [(None, None, None, "Saved.")]
-
 
 @special_command('\\nd', '\\nd [name]', 'Delete a named query.')
 def delete_named_query(pattern, **_):

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -234,6 +234,30 @@ def list_named_queries(verbose):
         status = ''
     return [('', rows, headers, status)]
 
+@special_command('\\np', '\\np name', 'Print a named query.')
+def print_named_query(pattern, **_):
+    """Save a new named query.
+    Returns (title, rows, headers, status)"""
+
+    usage = 'Syntax: \\np name.\n\n' + NamedQueries.instance.usage
+    if not pattern:
+        return [(None, None, None, usage)]
+
+    name = pattern.strip()
+    if (not name):
+        return [(None, None, None,
+            usage + 'Err: A name is required.')]
+
+    headers = ["Name", "Query"]
+    rows = [(r, NamedQueries.instance.get(r))
+            for r in NamedQueries.instance.list() if r == name]
+
+    status = ''
+    if not rows:
+        status = 'No match found'
+
+    return [('', rows, headers, status)]
+
 
 @special_command('\\ns', '\\ns name query', 'Save a named query.')
 def save_named_query(pattern, **_):

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from contextlib import contextmanager
 import re
+import fnmatch
 import sys
 import logging
 import click

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -234,9 +234,10 @@ def list_named_queries(verbose):
         status = ''
     return [('', rows, headers, status)]
 
-@special_command('\\np', '\\np name', 'Print a named query.')
-def print_named_query(pattern, **_):
-    """Save a new named query.
+@special_command('\\np', '\\np name_pattern', 'Print a named query.')
+def get_named_query(pattern, **_):
+    """Get a named query that matches name_pattern. The named pattern can be
+    a regular expression.
     Returns (title, rows, headers, status)"""
 
     usage = 'Syntax: \\np name.\n\n' + NamedQueries.instance.usage
@@ -250,7 +251,7 @@ def print_named_query(pattern, **_):
 
     headers = ["Name", "Query"]
     rows = [(r, NamedQueries.instance.get(r))
-            for r in NamedQueries.instance.list() if r == name]
+            for r in NamedQueries.instance.list() if re.search(name, r)]
 
     status = ''
     if not rows:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ autopep8==1.3.3
 coverage==4.3.4
 codecov>=1.5.1
 git+https://github.com/hayd/pep8radius.git
-configobj==5.0.6
+configobj>=5.0.6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ autopep8==1.3.3
 coverage==4.3.4
 codecov>=1.5.1
 git+https://github.com/hayd/pep8radius.git
+configobj==5.0.6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from dbutils import (create_db, db_connection, setup_db, teardown_db, TEST_DB_NAME)
 from pgspecial.main import PGSpecial
 
-@pytest.yield_fixture(scope='module')
+@pytest.fixture(scope='module')
 def connection():
     create_db(TEST_DB_NAME)
     connection = db_connection(TEST_DB_NAME)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import pytest
 from dbutils import (create_db, db_connection, setup_db, teardown_db, TEST_DB_NAME)
 from pgspecial.main import PGSpecial
 
+
 @pytest.fixture(scope='module')
 def connection():
     create_db(TEST_DB_NAME)

--- a/tests/test_named_queries.py
+++ b/tests/test_named_queries.py
@@ -1,6 +1,4 @@
-"""
-Tests for named queries
-"""
+"""Tests for named queries."""
 
 import pytest
 import configparser
@@ -10,18 +8,21 @@ from pgspecial.namedqueries import NamedQueries
 from pgspecial.main import PGSpecial
 from configobj import ConfigObj
 
+
 @pytest.fixture(scope='module')
 def named_query():
     with tempfile.NamedTemporaryFile() as f:
         NamedQueries.instance = NamedQueries.from_config(
-                ConfigObj(f))
+            ConfigObj(f))
         yield
         NamedQueries.instance = None
+
 
 def test_save_named_queries(named_query):
     PGSpecial().execute(None, '\\ns test select * from foo')
     expected = {'test': 'select * from foo'}
     assert NamedQueries.instance.list() == expected
+
 
 def test_delete_named_queries(named_query):
     PGSpecial().execute(None, '\\ns test_foo select * from foo')
@@ -30,12 +31,14 @@ def test_delete_named_queries(named_query):
     PGSpecial().execute(None, '\\nd test_foo')
     assert 'test_foo' not in NamedQueries.instance.list()
 
+
 def test_print_named_queries(named_query):
     PGSpecial().execute(None, '\\ns test_name select * from bar')
     assert 'test_name' in NamedQueries.instance.list()
 
     result = PGSpecial().execute(None, '\\np test_n.*')
-    assert result == [('', [('test_name', 'select * from bar')], ['Name', 'Query'], '')]
+    assert result == [
+        ('', [('test_name', 'select * from bar')], ['Name', 'Query'], '')]
 
     result = PGSpecial().execute(None, '\\np')
     assert result[0][:3] == (None, None, None,)

--- a/tests/test_named_queries.py
+++ b/tests/test_named_queries.py
@@ -1,0 +1,41 @@
+"""
+Tests for named queries
+"""
+
+import pytest
+import configparser
+import tempfile
+
+from pgspecial.namedqueries import NamedQueries
+from pgspecial.main import PGSpecial
+from configobj import ConfigObj
+
+@pytest.fixture(scope='module')
+def named_query():
+    with tempfile.NamedTemporaryFile() as f:
+        NamedQueries.instance = NamedQueries.from_config(
+                ConfigObj(f))
+        yield
+        NamedQueries.instance = None
+
+def test_save_named_queries(named_query):
+    PGSpecial().execute(None, '\\ns test select * from foo')
+    expected = {'test': 'select * from foo'}
+    assert NamedQueries.instance.list() == expected
+
+def test_delete_named_queries(named_query):
+    PGSpecial().execute(None, '\\ns test_foo select * from foo')
+    assert 'test_foo' in NamedQueries.instance.list()
+
+    PGSpecial().execute(None, '\\nd test_foo')
+    assert 'test_foo' not in NamedQueries.instance.list()
+
+def test_print_named_queries(named_query):
+    PGSpecial().execute(None, '\\ns test_name select * from bar')
+    assert 'test_name' in NamedQueries.instance.list()
+
+    result = PGSpecial().execute(None, '\\np test_name')
+    assert result == [('', [('test_name', 'select * from bar')], ['Name', 'Query'], '')]
+
+    result = PGSpecial().execute(None, '\\np')
+    assert result[0][:3] == (None, None, None,)

--- a/tests/test_named_queries.py
+++ b/tests/test_named_queries.py
@@ -34,7 +34,7 @@ def test_print_named_queries(named_query):
     PGSpecial().execute(None, '\\ns test_name select * from bar')
     assert 'test_name' in NamedQueries.instance.list()
 
-    result = PGSpecial().execute(None, '\\np test_name')
+    result = PGSpecial().execute(None, '\\np test_n.*')
     assert result == [('', [('test_name', 'select * from bar')], ['Name', 'Query'], '')]
 
     result = PGSpecial().execute(None, '\\np')

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -188,6 +188,53 @@ def test_slash_dn(executor):
 
 
 @dbtest
+def test_slash_dp(executor):
+    """List all schemas."""
+    results = executor('\dp')
+    title = None
+    rows = [('public', 'Inh1', 'table', None, '', ''),
+            ('public', 'inh2', 'table', None, '', ''),
+            ('public', 'mvw1', 'materialized view', None, '', ''),
+            ('public', 'tbl1', 'table', None, '', ''),
+            ('public', 'tbl2', 'table', None, '', ''),
+            ('public', 'tbl2_id2_seq', 'sequence', None, '', ''),
+            ('public', 'tbl3', 'table', None, '', ''),
+            ('public', 'vw1', 'view', None, '', '')]
+
+    headers = ['Schema', 'Name', 'Type',
+               'Access privileges', 'Column privileges', 'Policies']
+    status = 'SELECT %s' % len(rows)
+    expected = [title, rows, headers, status]
+    assert results == expected
+
+
+@dbtest
+def test_slash_dp_pattern(executor):
+    """List all schemas."""
+    results = executor('\dp i*2')
+    title = None
+    rows = [('public', 'inh2', 'table', None, '', '')]
+    headers = ['Schema', 'Name', 'Type',
+               'Access privileges', 'Column privileges', 'Policies']
+    status = 'SELECT %s' % len(rows)
+    expected = [title, rows, headers, status]
+    assert results == expected
+
+
+@dbtest
+def test_slash_dp_pattern_alias(executor):
+    """List all schemas."""
+    results = executor('\z i*2')
+    title = None
+    rows = [('public', 'inh2', 'table', None, '', '')]
+    headers = ['Schema', 'Name', 'Type',
+               'Access privileges', 'Column privileges', 'Policies']
+    status = 'SELECT %s' % len(rows)
+    expected = [title, rows, headers, status]
+    assert results == expected
+
+
+@dbtest
 def test_slash_dt(executor):
     """List all tables in public schema."""
     results = executor('\dt')

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
   #!/usr/bin/python
   # -*- coding: utf-8 -*-
 

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -1,7 +1,5 @@
-# coding: utf-8
-
-  #!/usr/bin/python
-  # -*- coding: utf-8 -*-
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 from dbutils import dbtest, POSTGRES_USER, foreign_db_environ
 import itertools


### PR DESCRIPTION
## Description
Extends named queries functionality by providing a special command `\np <named_query_name>`, that returns just the specific named query.

This PR also adds a new test suite for testing named_query related special commands.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
