### PR TITLE
Add `README.rst` to `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 exclude *
-include changelog.rst DEVELOP.rst License.txt requirements-dev.txt setup.py
+include changelog.rst DEVELOP.rst License.txt README.rst requirements-dev.txt setup.py
 include scripts/docparser.py scripts/README.rst tox.ini
 recursive-include pgspecial *.py
 recursive-include tests *.py


### PR DESCRIPTION
With the addition of `exclude *` to the `MANIFEST.in`, the `README.rst` is no longer being included in the sdist:
***xref:*** https://github.com/conda-forge/pgspecial-feedstock/pull/16#issuecomment-778549766

Without that file the `setup.py` fails and the package can't be built from the sdist:
https://github.com/dbcli/pgspecial/blob/d3e03b74b52be823f5d64adf9eb1894a56be7cbf/setup.py#L24

This should ensure the `README.rst` file is included in the sdist.