### PR TITLE
Named query positionial parameters aggregation

### DIFF
--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -175,18 +175,23 @@ def copy(cur, pattern, verbose):
 
 def subst_favorite_query_args(query, args):
     """replace positional parameters ($1,$2,...$n) in query."""
-    for idx, val in enumerate(args):
-        subst_var = "$" + str(idx + 1)
-        if subst_var not in query:
-            return [
-                None,
-                "query does not have substitution parameter "
-                + subst_var
-                + ":\n  "
-                + query,
-            ]
+    if "$*" in query:
+        query = query.replace("$*", ", ".join(args))
+    elif "$@" in query:
+        query = query.replace("$@", ", ".join(f"'{arg}'" for arg in args))
+    else:
+        for idx, val in enumerate(args):
+            subst_var = "$" + str(idx + 1)
+            if subst_var not in query:
+                return [
+                    None,
+                    "query does not have substitution parameter "
+                    + subst_var
+                    + ":\n  "
+                    + query,
+                ]
 
-        query = query.replace(subst_var, val)
+            query = query.replace(subst_var, val)
 
     match = re.search("\\$\\d+", query)
     if match:

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -36,3 +36,27 @@ def test_subst_favorite_query_args_missing_arg():
     subst_query, error = iocommands.subst_favorite_query_args(template_query, ("42",))
     assert subst_query is None
     assert error.startswith("missing substitution for ")
+
+
+@pytest.mark.parametrize(
+    "template_query,query_args,query",
+    [
+        (
+            "select * from foo where bar IN ($*)",
+            ("42", "1337"),
+            "select * from foo where bar IN (42, 1337)",
+        ),
+        (
+            "select * from foo where bar IN ($@)",
+            ("Alice", "Bob", "Charlie"),
+            "select * from foo where bar IN ('Alice', 'Bob', 'Charlie')",
+        ),
+    ],
+    ids=["raw aggregation", "string aggregation"],
+)
+def test_subst_favorite_query_args_aggregation(template_query, query_args, query):
+    subst_query, error = iocommands.subst_favorite_query_args(
+        template_query, query_args
+    )
+    assert error is None
+    assert subst_query == query

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -20,3 +20,19 @@ def test_plain_editor_commands_detected():
 
 def test_edit_view_command_detected():
     assert iocommands.editor_command(r"\ev myview") == r"\ev"
+
+
+def test_subst_favorite_query_args():
+    template_query = "select * from foo where bar = $2 and zoo = '$1'"
+    subst_query, error = iocommands.subst_favorite_query_args(
+        template_query, ("postgres", "42")
+    )
+    assert error is None
+    assert subst_query == "select * from foo where bar = 42 and zoo = 'postgres'"
+
+
+def test_subst_favorite_query_args_missing_arg():
+    template_query = "select * from foo where bar = $2 and zoo = '$1'"
+    subst_query, error = iocommands.subst_favorite_query_args(template_query, ("42",))
+    assert subst_query is None
+    assert error.startswith("missing substitution for ")


### PR DESCRIPTION
## Description
This pull-request propose an implementation for #106. The proposal adds 2 new placeholders `$*` and `$@`, respectively raw aggregation and string aggregation. The difference being that the later will quote the argument values, removing the need to quote the argument (e.g. `'foo'` instead of `\'foo\'`).
I took the addition to add tests for `subst_favorite_query_args` covering both current and new placeholders.

## Checklist
- [ ] I've added this contribution to the `changelog.rst`. <!-- will do if the proposal is accepted -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
