### PR TITLE
Upgrade pytest to latest version

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -117,8 +117,9 @@ After that, tests can be run with:
 
 ::
 
-    $ cd tests
     $ py.test
+
+Pytest configuration can be found in the ``tool.pytest.ini_options`` table of the ``pyproject.toml`` file.
 
 Enforcing the code style (linting)
 ------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,9 @@ exclude = '''
 )/
 '''
 
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--capture=sys --showlocals -rxs"
+testpaths = [
+    "tests",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest>=2.7.0
+pytest>=6.2.4
 mock>=1.0.1
 tox>=1.9.2
 psycopg2>=2.5.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from dbutils import create_db, db_connection, setup_db, teardown_db, TEST_DB_NAM
 from pgspecial.main import PGSpecial
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.fixture(scope="module")
 def connection():
     create_db(TEST_DB_NAME)
     connection = db_connection(TEST_DB_NAME)

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts=--capture=sys --showlocals -rxs


### PR DESCRIPTION
## Description
This pull-request propose to upgrade pytest to latest version (6.2.4) in order to:
- Replace the [deprecated yield fixture function decorator](https://docs.pytest.org/en/latest/deprecations.html#the-yield-fixture-function-decorator), which shows as a warning when [running tests](https://github.com/dbcli/pgspecial/runs/2548249091#step:6:22)
- Move pytest configuration to [pyproject.toml ](https://docs.pytest.org/en/latest/reference/customize.html#pyproject-toml)

I know some people are not fan of moving configuration to pyproject.toml and I would perfectly understand if you want to keep as is.

## Checklist
- [ ] I've added this contribution to the `changelog.rst`.
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
