### PR TITLE
Drop mock dev/test dependency, which is not actually used.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,11 @@
+1.13.1
+======
+
+Internal:
+---------
+
+* Drop unused dev/test dependency on mock (Thanks: `Benjamin Beasley`_).
+
 1.13.0
 ======
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 pytest>=6.2.4
-mock>=1.0.1
 tox>=1.9.2
 psycopg2>=2.5.4
 autopep8==1.3.3

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist = py36, py37, py38, py39
 [testenv]
 deps = pytest
-    mock
     psycopg2
     configobj
 commands = py.test {posargs}


### PR DESCRIPTION
## Description

Drop mock dependency, which is not actually used.

See also https://fedoraproject.org/wiki/Changes/DeprecatePythonMock


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
