### PR TITLE
Fix one more spot where backslash-escaping in a string literal was not quite right

### DIFF
--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -63,7 +63,7 @@ def get_editor_query(sql):
     # The reason we can't simply do .strip('\e') is that it strips characters,
     # not a substring. So it'll strip "e" in the end of the sql also!
     # Ex: "select * from style\e" -> "select * from styl".
-    pattern = re.compile("(^\\\e|\\\e$)")
+    pattern = re.compile(r"(^\\e|\\e$)")
     while pattern.search(sql):
         sql = pattern.sub("", sql)
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

This is a follow-up to https://github.com/dbcli/pgspecial/pull/116 and https://github.com/dbcli/pgspecial/pull/105 before that.

`r"(^\\e|\\e$)"` is equivalent to `"(^\\\\e|\\\\e$)"`.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`. **N/A, trivial**
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
