### PR TITLE
Throw an exception if we cannot parse the filename in \copy command.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,12 @@ Features:
 
 * Add support for the `\ddp` metacommand that lists the default privileges of Postgres objects (Thanks: `Roberto Dedoro`_)
 
+Bug fixes:
+----------
+
+* Throw an exception if the TO/FROM keyword is missing in the `\copy` command. (Thanks: `Amjith`_)
+
+
 1.12.1
 ======
 

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -127,7 +127,7 @@ def _index_of_file_name(tokenlist):
     for (idx, token) in reversed(list(enumerate(tokenlist[:-2]))):
         if token.is_keyword and token.value.upper() in ("TO", "FROM"):
             return idx + 2
-    return None
+    raise Exception("Missing keyword in \\copy command. Either TO or FROM is required.")
 
 
 @special_command(

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -841,10 +841,11 @@ def test_slash_copy_to_tsv(executor, tmpdir):
 @dbtest
 def test_slash_copy_throws_error_without_TO_or_FROM(executor):
     with pytest.raises(Exception) as exc_info:
-        executor(
-            "\copy (SELECT 'Montréal', 'Portland', 'Cleveland') INTO stdout "
-        )
-    assert str(exc_info.value) == 'Missing keyword in \\copy command. Either TO or FROM is required.'
+        executor("\copy (SELECT 'Montréal', 'Portland', 'Cleveland') INTO stdout ")
+    assert (
+        str(exc_info.value)
+        == "Missing keyword in \\copy command. Either TO or FROM is required."
+    )
 
 
 @dbtest

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+import pytest
 from dbutils import dbtest, POSTGRES_USER, foreign_db_environ, fdw_test
 import itertools
 
@@ -835,6 +836,15 @@ def test_slash_copy_to_tsv(executor, tmpdir):
     contents = infile.read()
     assert len(contents.splitlines()) == 1
     assert "Montréal" in contents
+
+
+@dbtest
+def test_slash_copy_throws_error_without_TO_or_FROM(executor):
+    with pytest.raises(Exception) as exc_info:
+        executor(
+            "\copy (SELECT 'Montréal', 'Portland', 'Cleveland') INTO stdout "
+        )
+    assert str(exc_info.value) == 'Missing keyword in \\copy command. Either TO or FROM is required.'
 
 
 @dbtest


### PR DESCRIPTION
## Description
Fixes https://github.com/dbcli/pgcli/issues/1277

Parsing for filename in `\copy` command will throw an exception if the FROM/TO keyword is missing. 

