### PR TITLE
Achieve better parity with psql's \watch

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -5,6 +5,7 @@ Bug fixes:
 ----------
 
 * Throw an exception if the TO/FROM keyword is missing in the `\copy` command. (Thanks: `Amjith`_)
+* Allow multiline SQL and use default of 2s timing for the `\watch` command. (Thanks: `Saif Hakim`_)
 
 1.13.1
 ======

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -11,9 +11,11 @@ import psycopg2
 from os.path import expanduser
 from .namedqueries import NamedQueries
 from . import export
-from .main import special_command
+from .main import show_extra_help_command, special_command
 
 NAMED_QUERY_PLACEHOLDERS = frozenset({"$1", "$*", "$@"})
+
+DEFAULT_WATCH_SECONDS = 2
 
 _logger = logging.getLogger(__name__)
 
@@ -47,10 +49,15 @@ def get_filename(sql):
 
 
 @export
+@show_extra_help_command(
+    "\\watch",
+    f"\\watch [sec={DEFAULT_WATCH_SECONDS}]",
+    "Execute query every `sec` seconds.",
+)
 def get_watch_command(command):
-    match = re.match("(.*?)[\\s]*\\\\watch (\\d+);?$", command)
+    match = re.match(r"(.*?)[\s]*\\watch(\s+\d+)?\s*;?\s*$", command, re.DOTALL)
     if match:
-        groups = match.groups()
+        groups = match.groups(default=f"{DEFAULT_WATCH_SECONDS}")
         return groups[0], int(groups[1])
     return None, None
 

--- a/pgspecial/main.py
+++ b/pgspecial/main.py
@@ -234,6 +234,23 @@ def parse_special_command(sql):
     return (command, verbose, arg.strip())
 
 
+def show_extra_help_command(command, syntax, description):
+    """
+    A decorator used internally for registering help for a command that is not
+    automatically executed via PGSpecial.execute, but invoked manually by the
+    caller (e.g. \watch).
+    """
+
+    @special_command(command, syntax, description, arg_type=NO_QUERY)
+    def placeholder():
+        raise RuntimeError
+
+    def wrapper(wrapped):
+        return wrapped
+
+    return wrapper
+
+
 def special_command(
     command,
     syntax,

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -6,6 +6,24 @@ import pytest
 from pgspecial import iocommands
 
 
+@pytest.mark.parametrize(
+    "command,expected_watch_command,expected_timing",
+    [
+        ("SELECT * FROM foo \\watch", "SELECT * FROM foo", 2),
+        ("SELECT * FROM foo \\watch 123", "SELECT * FROM foo", 123),
+        ("SELECT *\nFROM foo \\watch 1", "SELECT *\nFROM foo", 1),
+        ("SELECT * FROM foo \\watch   1  ", "SELECT * FROM foo", 1),
+        ("SELECT * FROM foo; \\watch    1 ; ", "SELECT * FROM foo;", 1),
+        ("SELECT * FROM foo;\\watch 1;", "SELECT * FROM foo;", 1),
+    ],
+)
+def test_get_watch_command(command, expected_watch_command, expected_timing):
+    assert iocommands.get_watch_command(command) == (
+        expected_watch_command,
+        expected_timing,
+    )
+
+
 def test_plain_editor_commands_detected():
     assert not iocommands.editor_command("select * from foo")
     assert not iocommands.editor_command(r"\easy does it")


### PR DESCRIPTION
## Description
- Include `\watch` in `\?` documentation
- Allow omitting a timing for default of `2s`
- Allow using `\watch` on multiline SQL
- Allow whitespace in more places

Ref dbcli/pgcli#544

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
