### PR TITLE
fix \dp command not working properly with schema pattern

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,7 @@ Bug fixes:
 
 * Throw an exception if the TO/FROM keyword is missing in the `\copy` command. (Thanks: `Amjith`_)
 * Allow multiline SQL and use default of 2s timing for the `\watch` command. (Thanks: `Saif Hakim`_)
+* Fix for the `\dp` metacommand to properly work with the schema name as pattern (Thanks: `Roberto Dedoro`_)
 
 1.13.1
 ======

--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -173,7 +173,7 @@ def list_privileges(cur, pattern, verbose):
     where_clause = """
         WHERE c.relkind IN ('r','v','m','S','f','p')
           {pattern}
-        AND n.nspname !~ '^pg_'
+          AND n.nspname !~ '^pg_'
     """
 
     params = []

--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -173,18 +173,27 @@ def list_privileges(cur, pattern, verbose):
     where_clause = """
         WHERE c.relkind IN ('r','v','m','S','f','p')
           {pattern}
-          AND n.nspname !~ '^pg_' AND pg_catalog.pg_table_is_visible(c.oid)
+        AND n.nspname !~ '^pg_'
     """
 
     params = []
     if pattern:
-        _, schema = sql_name_pattern(pattern)
-        where_clause = where_clause.format(
-            pattern=" AND c.relname OPERATOR(pg_catalog.~) %s COLLATE pg_catalog.default "
-        )
-        params.append(schema)
+        schema, table = sql_name_pattern(pattern)
+        if table:
+            pattern = (
+                " AND c.relname OPERATOR(pg_catalog.~) %s COLLATE pg_catalog.default "
+            )
+            params.append(table)
+        if schema:
+            pattern = (
+                pattern
+                + " AND n.nspname OPERATOR(pg_catalog.~) %s COLLATE pg_catalog.default "
+            )
+            params.append(schema)
     else:
-        where_clause = where_clause.format(pattern="")
+        pattern = " AND pg_catalog.pg_table_is_visible(c.oid) "
+
+    where_clause = where_clause.format(pattern=pattern)
     sql = cur.mogrify(sql + where_clause + " ORDER BY 1, 2", params)
 
     log.debug(sql)

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -242,11 +242,32 @@ def test_slash_dp(executor):
 
 
 @dbtest
-def test_slash_dp_pattern(executor):
+def test_slash_dp_pattern_table(executor):
     """List all schemas."""
     results = executor(r"\dp i*2")
     title = None
     rows = [("public", "inh2", "table", None, "", "")]
+    headers = [
+        "Schema",
+        "Name",
+        "Type",
+        "Access privileges",
+        "Column privileges",
+        "Policies",
+    ]
+    status = "SELECT %s" % len(rows)
+    expected = [title, rows, headers, status]
+    assert results == expected
+
+
+def test_slash_dp_pattern_schema(executor):
+    """List all schemas."""
+    results = executor(r"\dp schema2.*")
+    title = None
+    rows = [
+        ("schema2", "tbl2", "table", None, "", ""),
+        ("schema2", "tbl2_id2_seq", "sequence", None, "", ""),
+    ]
     headers = [
         "Schema",
         "Name",


### PR DESCRIPTION
## Description
Hello,
the `\dp` command was not working properly when the schema name was used as pattern.


## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
