### PR TITLE
Add a few comments about porting to Psycopg 3

### DIFF
--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -56,6 +56,10 @@ def list_databases(cur, pattern, verbose):
         """
         _, schema = sql_name_pattern(pattern)
         params.append(schema)
+    # pg3: mogrify is no more on psycopg 3
+    # pg3: if you really want to compose the query client side you should use
+    # pg3: `sql.SQL(query).format(params)`, but with `{}` instead of `%s` placeholders
+    # pg3: thinking about something similar in psycopg 3.1 but plans not finalised yet
     query = cur.mogrify(query + " ORDER BY 1", params)
     cur.execute(query)
     if cur.description:
@@ -71,6 +75,7 @@ def list_roles(cur, pattern, verbose):
     Returns (title, rows, headers, status)
     """
 
+    # pg3: cur.connection.info.server_version
     if cur.connection.server_version > 90000:
         sql = """
             SELECT r.rolname,

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -171,10 +171,14 @@ def copy(cur, pattern, verbose):
     else:
         raise Exception("Enclose filename in single quotes")
 
+    # pg3: I don't know what is pause_thread for here.
     with _paused_thread():
+        # pg3: COPY changed in psycopg3 and is no more file based: examples at
+        # pg3: https://www.psycopg.org/psycopg3/docs/basic/copy.html#copying-block-by-block
         cur.copy_expert("copy " + query, file)
 
     if cur.description:
+        # pg3 (and 2): x.name is probably more readable than x[0]
         headers = [x[0] for x in cur.description]
         return [(None, cur, headers, cur.statusmessage)]
     else:
@@ -250,6 +254,7 @@ def execute_named_query(cur, pattern, **_):
             if query is None:
                 raise Exception("Bad arguments\n" + params)
         cur.execute(query)
+    # pg3: (but psycopg2 too): you can use `except psycopg.errors.SyntaxError`
     except psycopg2.ProgrammingError as e:
         if e.pgcode == psycopg2.errorcodes.SYNTAX_ERROR and "%s" in query:
             raise Exception(


### PR DESCRIPTION
## Description

As per https://github.com/dbcli/pgcli/pull/1318, dropping a few comments about how certain idioms changed from Psycopg 2 to 3. I'll be available if you need more help porting.

See https://github.com/dbcli/pgcli/issues/1085#issuecomment-1047289518 for some background about the problems of this project with psycopg 2.

Let me know if I can help further :wave: 


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`. - no: no code changee yet
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code. - pre-commit fails as I don't have Python 3.7. Black run clean.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
