### PR TITLE
Add @dbtest decorator for test_slash_dp_pattern_schema

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,11 @@
+Upcoming
+========
+
+Bug fixes:
+----------
+
+* Add `pytest` mark `dbtest` to `test_slash_dp_pattern_schema` so it can be skipped when necessary. (Thanks: `Benjamin Beasley`_)
+
 1.13.1
 ======
 

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -260,6 +260,7 @@ def test_slash_dp_pattern_table(executor):
     assert results == expected
 
 
+@dbtest
 def test_slash_dp_pattern_schema(executor):
     """List all schemas."""
     results = executor(r"\dp schema2.*")


### PR DESCRIPTION
Like the other tests in `test_specials`, this test relies on a postgresql database properly configured for testing and should be skipped when none is present.

## Description
<!--- Describe your changes in detail. -->

Added `@dbtest` decorator that was missing from the new test `test_slash_dp_pattern_schema` in `tests/test_specials.py`.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
