### PR TITLE
Add optional editor argument to open_external_editor

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,7 +1,9 @@
 Upcoming:
 =========
 
-* TODO
+Internal:
+---------
+* Added argument to open_external_editor to specifiy desired editor.
 
 2.0.0 (2022-06-03):
 ===================

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -77,7 +77,7 @@ def get_editor_query(sql):
 
 
 @export
-def open_external_editor(filename=None, sql=None):
+def open_external_editor(filename=None, sql=None, editor=None):
     """
     Open external editor, wait for the user to type in his query,
     return the query.
@@ -96,6 +96,7 @@ def open_external_editor(filename=None, sql=None):
         "{sql}\n\n{marker}".format(sql=sql, marker=MARKER),
         filename=filename,
         extension=".sql",
+        editor=editor
     )
 
     if filename:

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -96,7 +96,7 @@ def open_external_editor(filename=None, sql=None, editor=None):
         "{sql}\n\n{marker}".format(sql=sql, marker=MARKER),
         filename=filename,
         extension=".sql",
-        editor=editor
+        editor=editor,
     )
 
     if filename:


### PR DESCRIPTION
## Description
I want to be able to use a non default editor in pgcli that I use daily. The click library does support an optional editor in it's click.edit function. As such, I have added an optional argument here to allow further changes in the pgcli project.

Python is not my daily language, as far as I'm aware adding this argument here will not break anything for the current consumers of this code but I am open to being corrected.

Max

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
