### PR TITLE
Fix view definition displaying 1 element tuple string

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,7 +1,7 @@
 Upcoming:
 =========
 
-* [YOUR CHANGES HERE].
+* Fixed displaying verbose view definitions when running `\d+`.
 
 2.0.1 (2022-06-17):
 ===================

--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -1126,7 +1126,7 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
         log.debug(sql)
         cur.execute(sql)
         if cur.rowcount > 0:
-            view_def = cur.fetchone()
+            (view_def,) = cur.fetchone()
 
     # Prepare the cells of the table to print.
     cells = []

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -167,6 +167,22 @@ def test_slash_d_table_verbose_2(executor):
 
 
 @dbtest
+def test_slash_d_view_verbose(executor):
+    title = None
+    headers = ["Column", "Type", "Modifiers", "Storage", "Description"]
+
+    results = executor(r"\d+ vw1")
+    rows = [
+        ["id1", "integer", "", "plain", None],
+        ["txt1", "text", "", "extended", None],
+    ]
+    status = "View definition:\n SELECT tbl1.id1,\n    tbl1.txt1\n   FROM tbl1; \n"
+
+    expected = [title, rows, headers, status]
+    assert results == expected
+
+
+@dbtest
 def test_slash_d_table_with_exclusion(executor):
     results = executor(r"\d tbl3")
     title = None


### PR DESCRIPTION
## Description

Currently in pgcli version 3.5.0, displaying view definitions with `\d+` appears as the following:
```
postgres@/tmp:postgres> \d+ test_vw
+----------+-----------------------+-----------+----------+-------------+
| Column   | Type                  | Modifiers | Storage  | Description |
|----------+-----------------------+-----------+----------+-------------|
| username | character varying(50) |           | extended | <null>      |
| value    | integer               |           | plain    | <null>      |
+----------+-----------------------+-----------+----------+-------------+
View definition:
(' SELECT test.username,\n    test.value\n   FROM test;',)
```

The view definitions displaying this way is new behavior to 3.5.0 and was not present in pgcli==3.4.1, which is the output shown below:
```
postgres@/tmp:postgres> \d+ test_vw
+----------+-----------------------+-----------+----------+-------------+
| Column   | Type                  | Modifiers | Storage  | Description |
|----------+-----------------------+-----------+----------+-------------|
| username | character varying(50) |           | extended | <null>      |
| value    | integer               |           | plain    | <null>      |
+----------+-----------------------+-----------+----------+-------------+
View definition:
 SELECT test.username,
    test.value
   FROM test;
```

I believe this behavior was introduced during [the switch to f-strings in this pgspecial commit](https://github.com/dbcli/pgspecial/commit/fe04290e650fe415f4af1bb8175f6eb5072bbe06#diff-cf24452337f7e469a63bdb9aaade3b088462d986e4e1a832d3d7f852b3510e33L1640), since python3 displays tuples with just a single string differently when using different string formatting methods:
```
>>> view_def = ("test",)
>>> "%s \n" % view_def
'test \n'
>>> f"{view_def} \n"
"('test',) \n"
```

This PR fixes this by making a minor change to unpack the 1-tuple. It also adds a test for displaying view definitions for a view. It is safe to always unpack the 1-tuple in this case since we know `cur.rowcount > 0`.

I did a cursory search through other instances of f-strings in pgspecial, and this was the only instance that I found that I think is negatively impacted by this behavior.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
