### PR TITLE
Fix typo in sequence describe SQL command, add missed quotation mark

### DIFF
--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -971,7 +971,7 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
     # If it's a seq, fetch it's value and store it for later.
     if tableinfo.relkind == "S":
         # Do stuff here.
-        sql = f"""SELECT * FROM "{schema_name}"."{relation_name}"""
+        sql = f'''SELECT * FROM "{schema_name}"."{relation_name}"'''
         log.debug(sql)
         cur.execute(sql)
         if not (cur.rowcount > 0):


### PR DESCRIPTION
## Description
Fixed `\d sequence` command processing — add missed quote mark after sequence name

<img width="544" alt="Снимок экрана 2023-01-15 в 18 01 54" src="https://user-images.githubusercontent.com/1895747/212551306-d220be54-00f2-4c71-a50a-61b8571acc2e.png">
