### PR TITLE
Add PostgreSQL 15 with a fix for \\dp and \\dn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
             postgres-version: '13'
           - python-version: '3.11'
             postgres-version: '14'
+          - python-version: '3.11'
+            postgres-version: '15'
 
     services:
       postgres:

--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -143,7 +143,7 @@ def list_privileges(cur, pattern, verbose):
                E' (RESTRICTIVE)'
                ELSE '' END
             || CASE WHEN polcmd != '*' THEN
-                   E' (' || polcmd || E'):'
+                   E' (' || polcmd::pg_catalog.text || E'):'
                ELSE E':'
                END
             || CASE WHEN polqual IS NOT NULL THEN

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from dbutils import dbtest, POSTGRES_USER, foreign_db_environ, fdw_test
+from dbutils import dbtest, POSTGRES_USER, SERVER_VERSION, foreign_db_environ, fdw_test
 import itertools
 
 objects_listing_headers = ["Schema", "Name", "Type", "Owner", "Size", "Description"]
@@ -216,12 +216,21 @@ def test_slash_dn(executor):
     """List all schemas."""
     results = executor(r"\dn")
     title = None
-    rows = [
-        ("public", POSTGRES_USER),
-        ("schema1", POSTGRES_USER),
-        ("schema2", POSTGRES_USER),
-        ("schema3", POSTGRES_USER),
-    ]
+    if SERVER_VERSION >= 150001:
+        rows = [
+            ("public", "pg_database_owner"),
+            ("schema1", POSTGRES_USER),
+            ("schema2", POSTGRES_USER),
+            ("schema3", POSTGRES_USER),
+        ]
+    else:
+        rows = [
+            ("public", POSTGRES_USER),
+            ("schema1", POSTGRES_USER),
+            ("schema2", POSTGRES_USER),
+            ("schema3", POSTGRES_USER),
+        ]
+
     headers = ["Name", "Owner"]
     status = "SELECT %s" % len(rows)
     expected = [title, rows, headers, status]


### PR DESCRIPTION
Add PostgreSQL v15 into build matrix. Requires a change in `\\dp` and `\\dn`.

Related to https://github.com/dbcli/pgspecial/issues/134.