### PR TITLE
Declare the build-system in pyproject.toml, per PEP 517

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 exclude *
-include changelog.rst DEVELOP.rst License.txt README.rst requirements-dev.txt setup.py
+include changelog.rst DEVELOP.rst License.txt pyproject.toml README.rst requirements-dev.txt setup.py
 include scripts/docparser.py scripts/README.rst tox.ini
 recursive-include pgspecial *.py
 recursive-include tests *.py

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,8 @@
+Upcoming
+========
+
+* Added `build-system` section to `pyproject.toml` to use the modern setuptools backend.
+
 2.1.0 (2023-03-31)
 =========
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 88
 target-version = ['py37']


### PR DESCRIPTION
## Description
Explicitly declare the build system per PEP 517, in order to use
the modern setuptools backend rather than the legacy fallback.  NFC.

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
