### PR TITLE
Fix test_slash_l* to support non-en_US locales

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Run unit tests
+        env:
+          LANG: en_US.UTF-8
         run: coverage run --source pgspecial -m pytest
 
       - name: Run Black

--- a/changelog.rst
+++ b/changelog.rst
@@ -2,6 +2,7 @@ Upcoming
 ========
 
 * Added `build-system` section to `pyproject.toml` to use the modern setuptools backend.
+* Fixed test failures when locale other than `en_US` is used.
 
 2.1.0 (2023-03-31)
 =========

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
 import pytest
 from dbutils import create_db, db_connection, setup_db, teardown_db, TEST_DB_NAME
+import locale
 from pgspecial.main import PGSpecial
+
+
+locale.setlocale(locale.LC_ALL, "")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Description
Update the tests to expect the current locale rather than `en_US`. While technically this isn't 100% guaranteed to be the same locale as the database is running on, I think we can reasonably assume that for the purpose of testing they are the same.  Non-UTF-8 locales still are not supported but the other tests seem to be unable to handle them well anyway.

Fixes #140


## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
