### PR TITLE
Fix SyntaxWarning with Python 3.12

### DIFF
--- a/pgspecial/main.py
+++ b/pgspecial/main.py
@@ -234,7 +234,7 @@ def parse_special_command(sql):
 
 
 def show_extra_help_command(command, syntax, description):
-    """
+    r"""
     A decorator used internally for registering help for a command that is not
     automatically executed via PGSpecial.execute, but invoked manually by the
     caller (e.g. \watch).


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

When using Python 3.12, e.g. when installing via Homebrew with the latest Python installed, I get this warning:

```
pgspecial/main.py:237: SyntaxWarning: invalid escape sequence '\w'
```

It also displays every time I run `pgcli --version`.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`.
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
