### PR TITLE
fix bad f-string placement on `describe_one_table_details`

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,10 @@
+Upcoming
+========
+
+Bug fixes:
+----------
+* Fix `\d` when used with a pattern
+
 2.1.1 (2023-10-29)
 ==================
 

--- a/pgspecial/dbcommands.py
+++ b/pgspecial/dbcommands.py
@@ -1069,8 +1069,8 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
     if tableinfo.relkind == "i" or tableinfo.relkind == "I":
         if cur.connection.info.server_version >= 110000:
             sql += (
-                f",\n CASE WHEN a.attnum <= (SELECT i.indnkeyatts FROM pg_catalog.pg_index i "
-                "WHERE i.indexrelid = '{oid}') THEN 'yes' ELSE 'no' END AS is_key"
+                ",\n CASE WHEN a.attnum <= (SELECT i.indnkeyatts FROM pg_catalog.pg_index i "
+                f"WHERE i.indexrelid = '{oid}') THEN 'yes' ELSE 'no' END AS is_key"
             )
             att_cols["indexkey"] = cols
             cols += 1


### PR DESCRIPTION
## Description
The string is split in 2 and and concatenated implicitly, but the f-string is applied only to the first one, which has no variables to replace, while the second one does and inserts a literal `{oid}`

this is breaking `\d` on patterns with a pg syntax error e.g:

`\d mytabl*`


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`.
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
