### PR TITLE
Make \copy case-insensitive

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,8 @@
+Upcoming
+========
+
+* Made `\copy` case-insensitive, as it is in `psql`.
+
 2.1.2 (2024-05-15)
 ==================
 

--- a/pgspecial/iocommands.py
+++ b/pgspecial/iocommands.py
@@ -132,6 +132,7 @@ def _index_of_file_name(tokenlist):
     "\\copy",
     "\\copy [tablename] to/from [filename]",
     "Copy data between a file and a table.",
+    case_sensitive=False,
 )
 def copy(cur, pattern, verbose):
     """Copies table data to/from files"""

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -1035,6 +1035,18 @@ def test_slash_copy_from_csv(executor, connection, tmpdir):
 
 
 @dbtest
+def test_slash_copy_case_insensitive(executor, tmpdir):
+    filepath = tmpdir.join("pycons.tsv")
+    executor(
+        r"\COPY (SELECT 'Montréal', 'Portland', 'Cleveland') TO '{0}' ".format(filepath)
+    )
+    infile = filepath.open(encoding="utf-8")
+    contents = infile.read()
+    assert len(contents.splitlines()) == 1
+    assert "Montréal" in contents
+
+
+@dbtest
 def test_slash_sf(executor):
     results = executor(r"\sf func1")
     title = None


### PR DESCRIPTION
`\COPY` behaves exactly like `\copy` in `psql` - see [psql's slash-command-parsing
function](https://github.com/postgres/postgres/blob/ea15816928c1bbcab749205a263d82daea28a3e0/src/bin/psql/command.c#L330) and note the use of `pg_strcasecmp`. So some users expect to be able to use `\COPY` in pgcli. This commit makes that happen.

## Description
<!--- Describe your changes in detail. -->
`psql` treats `\copy`, `\COPY`, `\cOpY`, etc. the same way. (See [postgres source](https://github.com/postgres/postgres/blob/ea15816928c1bbcab749205a263d82daea28a3e0/src/bin/psql/command.c#L330).) I hadn't known that until earlier today - a coworker who was trying out `pgcli` for the first time in a while was disappointed that `pgcli` still doesn't support `\COPY`. This PR is meant to fix that.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)

Caveat 1: I'm not sure I used `black` correctly. I managed to kick it off imperatively at some point against the whole repo, and it only seemed to make one change (deleting a blank line in a file I hadn't edited). So hopefully it's okay with whatever I've done here?

Caveat 2: a couple of integration tests are red for me locally. Specifically, ones about listing users seem surprised/upset by the amount of stuff that's owned by my local macOS user and not `postgres`. I'm pretty sure this is just because I messed up setting up my local database, and not because of anything introduced by my code change? But I wanted to call attention to it in case I'm misunderstanding.