### PR TITLE
Remove bogus litecli script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,6 @@ dev = [
     "pdbpp>=0.10.3",
 ]
 
-[project.scripts]
-litecli = "litecli.main:cli"
-
 [build-system]
 requires = ["setuptools>=64.0", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This seems to have been copy-pasted from https://github.com/dbcli/litecli.

## Description
<!--- Describe your changes in detail. -->

Removed a `litecli` script definition, introduced in 2.2.0, which this project does not have!

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`.
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
